### PR TITLE
ci: run checks only on pull requests

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - main
       - staging
-  push:
-    branches:
-      - main
-      - staging
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -5,13 +5,6 @@ on:
     branches:
       - main
       - staging
-  push:
-    branches:
-      - main
-      - staging
-  workflow_dispatch:
-  schedule:
-    - cron: "17 3 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- remove direct push and manual triggers from PR CI
- remove direct push, manual, and scheduled triggers from secret scan
- keep both workflows running for PRs targeting main or staging

## Validation
- git diff --check
