### PR TITLE
fix: restore worker ci checks

### DIFF
--- a/apps/worker/app/core/tasks/kb_tasks.py
+++ b/apps/worker/app/core/tasks/kb_tasks.py
@@ -688,10 +688,7 @@ def _parse(job_id: str, user_id: str | None):
 
             # 1.5. Garbage Collection: Remove redundant local media files
             try:
-                from shared.core.database_sync import get_sync_db_context
                 from shared.services.retrieval.publication_service import RetrievalPublicationService
-                from shared.models.database.job import Job
-                from sqlalchemy import select
                 
                 with get_sync_db_context() as db:
                     job_record = db.execute(select(Job).where(Job.job_id == job_id)).scalar_one_or_none()

--- a/apps/worker/app/services/document_parser/doc_parser.py
+++ b/apps/worker/app/services/document_parser/doc_parser.py
@@ -1,5 +1,4 @@
 # pyright: reportArgumentType=false, reportAttributeAccessIssue=false, reportCallIssue=false, reportGeneralTypeIssues=false
-import hashlib
 import io
 import json
 import os

--- a/apps/worker/app/services/document_parser/md_parser.py
+++ b/apps/worker/app/services/document_parser/md_parser.py
@@ -1,5 +1,4 @@
 # pyright: reportArgumentType=false, reportAssignmentType=false, reportOptionalIterable=false, reportOptionalMemberAccess=false, reportOptionalOperand=false, reportOptionalSubscript=false
-import hashlib
 import json
 import os
 import re

--- a/packages/shared-python/shared/services/retrieval/publication_service.py
+++ b/packages/shared-python/shared/services/retrieval/publication_service.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from loguru import logger
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 from shared.models.database.document import Document, DocumentChunk, DocumentSection
@@ -201,7 +201,7 @@ class RetrievalPublicationService:
         job_id: str,
         job_result_id: str,
         chunks: List[Dict[str, Any]],
-    ) -> Optional[Dict[str, str]]:
+    ) -> Optional[Dict[str, Any]]:
         job = db.execute(select(Job).where(Job.job_id == job_id)).scalar_one_or_none()
         if not job:
             logger.warning(f"Job not found for document publication: {job_id}")
@@ -221,7 +221,7 @@ class RetrievalPublicationService:
         job: Job,
         job_result_id: str,
         chunks: List[Dict[str, Any]],
-    ) -> Optional[Dict[str, str]]:
+    ) -> Optional[Dict[str, Any]]:
 
         job_metadata = job.job_metadata or {}
         namespace = job_metadata.get("namespace") or "default"

--- a/packages/shared-python/shared/utils/text_utils.py
+++ b/packages/shared-python/shared/utils/text_utils.py
@@ -20,6 +20,7 @@ except (ImportError, OSError):  # blingfire ships a native lib; fall back to syn
 
 class _JiebaModule(Protocol):
     def lcut(self, sentence: str) -> list[str]: ...
+    def cut(self, sentence: str) -> list[str]: ...
 
 
 warnings.filterwarnings(


### PR DESCRIPTION
Replacement for the earlier fix PR, with the branch name using the requested wangbinqi username. Fixes the merged PR CI failure from https://github.com/Ontos-AI/knowhere/actions/runs/25491082794. Summary: remove the parse-task local import shadowing that made database symbols unbound, clean lint-only unused imports, and align shared publication/jieba types with pyright. Verification: make lint; make typecheck; uv run pytest apps/api/tests apps/worker/tests/contract -q.