### PR TITLE
fix: downgrade insufficient credits billing log

### DIFF
--- a/apps/worker/app/core/tasks/kb_tasks.py
+++ b/apps/worker/app/core/tasks/kb_tasks.py
@@ -471,7 +471,7 @@ def _parse(job_id: str, user_id: str | None):
                             filename=filename,
                         )
                     except InsufficientCreditsException:
-                        logger.error(
+                        logger.warning(
                             f"Billing failed: job_id={job_id}, user_id={job_user_id}"
                         )
                         billing_amount = billing_service.estimate_page_charge(


### PR DESCRIPTION
## Summary
- Downgrade the expected insufficient-credits billing log from error to warning in the worker parse billing path.
- Keep the `PAYMENT_REQUIRED` job failure behavior unchanged.

## Verification
- `uv run --package knowhere-worker-app --group dev pytest apps/worker/tests/contract/test_parse_task_contract.py -q`
- `uv run --group lint ruff check apps/worker/app/core/tasks/kb_tasks.py`
