### PR TITLE
Remove asset_url from document chunk API responses

### DIFF
--- a/apps/api/app/api/v1/routes/documents.py
+++ b/apps/api/app/api/v1/routes/documents.py
@@ -82,7 +82,6 @@ async def list_document_chunks(
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(50, ge=1, le=200, description="Items per page"),
     chunk_type: DocumentChunkType | None = Query(None, description="Chunk type filter"),
-    include_asset_urls: bool = Query(False, description="Include generated asset URLs"),
     current_user: CurrentUser = Depends(with_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -93,7 +92,6 @@ async def list_document_chunks(
         page=page,
         page_size=page_size,
         chunk_type=chunk_type,
-        include_asset_urls=include_asset_urls,
     )
     if response is None:
         raise NotFoundException(
@@ -108,7 +106,6 @@ async def list_document_chunks(
 async def get_document_chunk(
     document_id: str,
     document_chunk_id: str,
-    include_asset_urls: bool = Query(False, description="Include generated asset URLs"),
     current_user: CurrentUser = Depends(with_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -117,7 +114,6 @@ async def get_document_chunk(
         user_id=current_user.user_id,
         document_id=document_id,
         document_chunk_id=document_chunk_id,
-        include_asset_urls=include_asset_urls,
     )
     if response is None:
         raise NotFoundException(

--- a/apps/api/app/services/document_service.py
+++ b/apps/api/app/services/document_service.py
@@ -17,9 +17,6 @@ from shared.services.retrieval.cache_service import (
     invalidate_retrieval_cache_namespaces,
 )
 from shared.services.retrieval.graph_service import DocumentGraphService, GraphScope
-from shared.services.storage.result_storage import get_result_storage
-
-_MEDIA_CHUNK_TYPES = {"image", "table"}
 
 
 def document_payload(document) -> dict[str, Any]:
@@ -74,7 +71,6 @@ class DocumentService:
         page: int,
         page_size: int,
         chunk_type: str | None,
-        include_asset_urls: bool,
     ) -> dict[str, Any] | None:
         document = await self._repository.get_document(
             db,
@@ -119,8 +115,6 @@ class DocumentService:
             self._chunk_payload(
                 chunk=chunk,
                 section=section,
-                job_id=job_result.job_id,
-                include_asset_urls=include_asset_urls,
             )
             for chunk, section, job_result in rows
         ]
@@ -147,7 +141,6 @@ class DocumentService:
         user_id: str,
         document_id: str,
         document_chunk_id: str,
-        include_asset_urls: bool,
     ) -> dict[str, Any] | None:
         document = await self._repository.get_document(
             db,
@@ -175,8 +168,6 @@ class DocumentService:
             "chunk": self._chunk_payload(
                 chunk=chunk,
                 section=section,
-                job_id=job_result.job_id,
-                include_asset_urls=include_asset_urls,
             ),
         }
 
@@ -201,8 +192,6 @@ class DocumentService:
         *,
         chunk: DocumentChunk,
         section: DocumentSection | None,
-        job_id: str,
-        include_asset_urls: bool,
     ) -> dict[str, Any]:
         chunk_type = _normalize_chunk_type(chunk.chunk_type)
         file_path = chunk.file_path
@@ -217,39 +206,8 @@ class DocumentService:
             "file_path": file_path,
             "sort_order": chunk.sort_order,
             "metadata": chunk.chunk_metadata,
-            "asset_url": self._asset_url(
-                chunk_type=chunk_type,
-                file_path=file_path,
-                job_id=job_id,
-                include_asset_urls=include_asset_urls,
-            ),
             "created_at": _datetime_payload(chunk.created_at),
         }
-
-    def _asset_url(
-        self,
-        *,
-        chunk_type: str,
-        file_path: str | None,
-        job_id: str,
-        include_asset_urls: bool,
-    ) -> str | None:
-        if (
-            not include_asset_urls
-            or chunk_type not in _MEDIA_CHUNK_TYPES
-            or not file_path
-        ):
-            return None
-
-        try:
-            result_storage = get_result_storage()
-            return result_storage.generate_artifact_url(
-                job_id=job_id,
-                artifact_ref=file_path,
-            )
-        except Exception as e:
-            logger.warning(f"Failed to generate document chunk asset URL: {e}")
-            return None
 
     async def archive_document(
         self,

--- a/apps/api/tests/contract/test_documents_contract.py
+++ b/apps/api/tests/contract/test_documents_contract.py
@@ -667,7 +667,6 @@ async def test_should_list_current_document_chunks_by_document_id(
             "file_path": None,
             "sort_order": 0,
             "metadata": {"summary": "Intro", "page_nums": [1]},
-            "asset_url": None,
             "created_at": chunks[0]["created_at"],
         }
     ]
@@ -747,7 +746,6 @@ async def test_should_return_one_document_chunk_by_document_chunk_id(
     assert chunk["source_chunk_path"] == "Chapter 1/Figure"
     assert chunk["file_path"] == "images/figure-1.png"
     assert chunk["metadata"] == {"summary": "Figure", "page_nums": [3]}
-    assert chunk["asset_url"] is None
     assert chunk["created_at"]
 
 


### PR DESCRIPTION
## Summary

Remove the `asset_url` field from document chunk API responses. The chunk list and single-chunk endpoints previously included an `asset_url` property (either a generated URL or `null`) alongside an `include_asset_urls` query parameter that controlled URL generation. This field does not belong in the chunk API, so the associated logic is removed.

## Changes

- `apps/api/app/services/document_service.py` — Removed `_asset_url` helper method, `_MEDIA_CHUNK_TYPES` constant, `include_asset_urls` parameter from service methods, and the `asset_url` field from `_chunk_payload`
- `apps/api/app/api/v1/routes/documents.py` — Removed `include_asset_urls` query parameter from `GET /documents/{id}/chunks` and `GET /documents/{id}/chunks/{chunk_id}`
- `apps/api/tests/contract/test_documents_contract.py` — Removed `asset_url` field from chunk response assertions

## Test results

```
apps/api/tests/contract/test_documents_contract.py: 9 passed in 15.93s
```