### PR TITLE
fix: remove agentic internal fields from empty query contract test

### DIFF
--- a/apps/api/tests/contract/test_retrieval_contract.py
+++ b/apps/api/tests/contract/test_retrieval_contract.py
@@ -183,12 +183,7 @@ async def test_should_return_empty_results_for_an_empty_query(
         "router_used": "empty_query_filtered",
         "results": [],
         "answer_text": None,
-        "final_strategy_used": None,
-        "plan": None,
-        "planner_snapshot": None,
         "referenced_chunks": [],
-        "steps": None,
-        "wallet_snapshot": None,
     }
 
 


### PR DESCRIPTION
This PR fixes a failing contract test (`test_should_return_empty_results_for_an_empty_query`) by removing internal agentic retrieval fields (`plan`, `steps`, `wallet_snapshot`, etc.) from the expected response JSON. These fields were intentionally removed from the API response to clean up the API schema and hide internal implementation details from clients. The test now correctly asserts against the updated API schema.