### PR TITLE
fix: resolve pyright typecheck errors in probe_sample_pages and update git_sync skill

### DIFF
--- a/apps/worker/app/services/document_agent/tools/probe_sample_pages.py
+++ b/apps/worker/app/services/document_agent/tools/probe_sample_pages.py
@@ -166,9 +166,14 @@ def _sample_pages_worker(
     doc = pymupdf.open(pdf_path)
     try:
         page_count = int(doc.page_count)
+        safe_strategy: SampleStrategy = "stratified"
+        if strategy == "uniform":
+            safe_strategy = "uniform"
+        elif strategy == "key_pages":
+            safe_strategy = "key_pages"
         indices = _choose_sample_indices(
             page_count,
-            strategy=strategy if strategy in {"stratified", "uniform", "key_pages"} else "stratified",
+            strategy=safe_strategy,
             max_samples=max_samples,
         )
         sampled_pages = [_extract_page_features(doc[idx], idx) for idx in indices]


### PR DESCRIPTION
This PR fixes the Pyright type-checking error in `probe_sample_pages.py` by properly casting the strategy variable, resolving CI failures. It also updates the `git_sync` skill document to enforce strict local exit-code checks for `make typecheck` and `make lint` before pushing.