### PR TITLE
docs: add 'What We Are' heading, convert intro to normal text

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@
   🖥️ <a href="https://github.com/Ontos-AI/knowhere-dashboard">Dashboard</a>
 </p>
 
-> **We're not building the next document parser — we're building document memory infrastructure that agents can actually consume.**
+## What We Are
 
->Knowhere is the open-source infrastructure that turns unstructured documents into persistent, navigable memory for AI agents. It automates the full pipeline — parsing, hierarchy extraction, multi-modal structuring, and graph construction — so your agents get structured, high-quality context optimized for *Agentic RAG*, *traditional vector-based RAG*, and *any LLM-powered workflow*.
+**We're not building the next document parser — we're building document memory infrastructure that agents can actually consume.**
+
+Knowhere is the open-source infrastructure that turns unstructured documents into persistent, navigable memory for AI agents. It automates the full pipeline — parsing, hierarchy extraction, multi-modal structuring, and graph construction — so your agents get structured, high-quality context optimized for *Agentic RAG*, *traditional vector-based RAG*, and *any LLM-powered workflow*.
 
 > [!TIP]
 > Knowhere stands on the shoulders of excellent open-source parsers (MinerU, Docling, Marker, and others) — and actively improves upon them. We contribute **memory-oriented parsing optimizations** that fix real-world deficiencies in existing tools, and we're pursuing **agentic parsing** to push accuracy even further. Beyond parsing, Knowhere focuses on what turns raw extraction into usable agent memory: **reconstructing hierarchical structure**, **extracting and normalizing multi-modal assets**, **building navigable cross-document graphs**, and **persisting it all as long-term, citable memory** that AI agents can search, navigate, and reason over.


### PR DESCRIPTION
## Summary

Minor README formatting improvement for the product positioning section introduced in PR #71.

### Changes
- **Added `## What We Are` heading**: Gives the positioning block a proper section title for better navigation and visual hierarchy.
- **Converted slogan and product description from blockquote to normal text**: The bold slogan and the product definition paragraph were previously rendered as gray blockquotes. They are now standard white text for better readability and visual prominence.
- **TIP callout preserved as-is**: The detailed explanation about standing on open-source parsers remains in the green TIP box.

Documentation-only change. No code modifications.