### PR TITLE
docs: restore README banner image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img width="1000" height="233" alt="20260506-102713" src="https://github.com/user-attachments/assets/896e64d2-e50e-4158-b71c-bc69e11c7c65" />
+
 <h1 align="center">Build AI Agent Memory from Real-World Documents</h1>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- Restores the full-width banner image at the top of the README that was accidentally removed in PR #65 as part of a larger README rewrite.

## Context

Tracked in issue #80. The banner provides strong visual impact on the project's landing page and carries the Knowhere brand identity. Its absence makes the README open cold with a plain heading, indistinguishable from thousands of other repos.

## Changes

- `README.md`: re-adds the `<img>` banner tag as the first element of the file.

Made with [Cursor](https://cursor.com)