### PR TITLE
docs: reposition product positioning statement to after benchmark chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@
 
 ## What We Are
 
-**We're not developing the next MinerU, instead, we're building document memory infrastructure that agents can effectively consume.**
-
 Knowhere turns unstructured documents into persistent, navigable memory for AI agents. It handles parsing, hierarchy extraction, multi-modal structuring, and graph construction, giving your agents structured, high-quality context for *Agentic RAG*, *traditional RAG*, or any LLM workflow.
 
 > [!TIP]
@@ -84,6 +82,8 @@ Knowhere enhances the accuracy of AI agents when performing tasks (e.g., searchi
 <p align="center">
   <img alt="Benchmark Performance: Agent + Knowhere vs Others" src="docs/assets/benchmark.png" width="900">
 </p>
+
+> **We're not developing the next MinerU — we're building document memory infrastructure that agents can effectively consume.**
 
 ### Key Advantages
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ## What We Are
 
-Knowhere turns unstructured documents into persistent, navigable memory for AI agents. It handles parsing, hierarchy extraction, multi-modal structuring, and graph construction, giving your agents structured, high-quality context for *Agentic RAG*, *traditional RAG*, or any LLM workflow.
+Knowhere turns unstructured documents into persistent, navigable memory for AI agents. It handles parsing, hierarchy identification, multi-modal extraction and labeling, and graph construction, giving your agents structured, high-quality context for information retrieval or any LLM workflow.
 
 > [!TIP]
 > Knowhere stands on the shoulders of giants like MinerU and Pymupdf. We take their output, optimize it, and then build **hierarchical structure** and **multi-modal cross-document graphs** on top. The result is a persistent, citable memory layer purpose-built for agent consumption.


### PR DESCRIPTION
Closes #84

## What Changed

Moves the bold positioning statement *'We're not developing the next MinerU — we're building document memory infrastructure that agents can effectively consume.'* from the very top of the 'What We Are' section to immediately after the benchmark performance chart, as a blockquote before 'Key Advantages'.

## Rationale

At the top of the page, the statement reads as a defensive opener before the reader has any context or evidence. After the benchmark chart — where the reader has just seen concrete performance data against raw parsing baselines — the same statement becomes a natural, confident interpretation of what those numbers mean: Knowhere is not competing on raw parsing fidelity, it is providing a higher-level memory infrastructure layer that agents can navigate and cite.

The flow now reads:
1. What Knowhere does (intro)
2. How it works (parse → retrieve)
3. Benchmark data (proof)
4. **Positioning insight** (why this matters)
5. Key Advantages (specifics)

## Changes
- Removed bold statement from 'What We Are' opening
- Inserted as a `>` blockquote between the benchmark chart and 'Key Advantages'