### PR TITLE
Assert oversized PDFs skip billing

### DIFF
--- a/apps/worker/tests/contract/test_parse_task_contract.py
+++ b/apps/worker/tests/contract/test_parse_task_contract.py
@@ -377,7 +377,7 @@ def test_should_reject_pdf_when_page_count_exceeds_configured_limit(
 ) -> None:
     contract = WorkerParseContract.create()
     contract.use_workspace_root(monkeypatch, tmp_path)
-    contract.use_billing(monkeypatch, is_enabled=False)
+    contract.use_billing(monkeypatch, is_enabled=True)
 
     max_pdf_page_limit: int = 1
     actual_page_count: int = 2
@@ -426,3 +426,9 @@ def test_should_reject_pdf_when_page_count_exceeds_configured_limit(
             }
         ]
     }
+
+    billing = contract.observe_user_billing(job["user_id"])
+    assert billing["balance"] is None
+    assert billing["transaction_types"] == []
+    assert billing["transaction_counts"] == {}
+    assert billing["system_grant_payment_count"] == 0


### PR DESCRIPTION
## Summary
- Strengthen the worker contract for PDF page-limit rejection while billing is enabled.
- Assert oversized PDFs fail before any billing side effects are created.
- Verify the failed job records skipped billing, no balance row, no credit transactions, and no system-grant payment.

## Tests
- GitHub PR CI
