### PR TITLE
fix(retrieval): surface real scores in agentic results, replace hardcoded 1.0 with None

### DIFF
--- a/apps/api/tests/contract/test_retrieval_contract.py
+++ b/apps/api/tests/contract/test_retrieval_contract.py
@@ -541,7 +541,10 @@ async def test_agentic_retrieval_should_reference_root_only_document_content(
         "section_path": "root-only.pdf",
         "file_path": None,
         "job_id": rooted_document["job_id"],
-    } in referenced_chunks
+    } in [
+        {k: v for k, v in ref.items() if k != "score"}
+        for ref in referenced_chunks
+    ]
     assert results[0]["content"] == "root only diluted earnings marker content"
     assert results[0]["source"] == {
         "document_id": rooted_document["document_id"],
@@ -599,7 +602,10 @@ async def test_agentic_retrieval_should_reference_discovery_content_when_navigat
         "section_path": discovered_document["section_path"],
         "file_path": None,
         "job_id": discovered_document["job_id"],
-    } in referenced_chunks
+    } in [
+        {k: v for k, v in ref.items() if k != "score"}
+        for ref in referenced_chunks
+    ]
     assert results[0]["content"] == "discovery fallback EBITDA margin marker content"
     assert results[0]["source"] == {
         "document_id": discovered_document["document_id"],

--- a/packages/shared-python/shared/services/retrieval/agentic/core/types.py
+++ b/packages/shared-python/shared/services/retrieval/agentic/core/types.py
@@ -132,13 +132,15 @@ class DocTreeNode:
                     child.add_leaf_chunks(leaf_path, self.leaf_content.pop(leaf_path))
             child.reparent_leaf_content()
 
-    def collect_referenced_ids(self, *, document_name: str = '') -> list[dict[str, str]]:
+    def collect_referenced_ids(self, *, document_name: str = '') -> list[dict[str, Any]]:
         """Extract minimal chunk references from all hydrated leaves.
 
         Returns deduplicated list of {chunk_id, document_id, chunk_type,
-        section_path, file_path, job_id} for hit stats and frontend display.
+        section_path, file_path, job_id, score} for hit stats and frontend
+        display. ``score`` carries the real retrieval score (discovery RRF or
+        navigation confidence) so callers can surface it in results.
         """
-        refs: list[dict[str, str]] = []
+        refs: list[dict[str, Any]] = []
         seen: set[str] = set()
         for row in self.flatten_chunk_rows():
             cid = row.get('chunk_id', '')
@@ -154,6 +156,7 @@ class DocTreeNode:
                     'section_path': section_path,
                     'file_path': row.get('file_path', ''),
                     'job_id': row.get('job_id', ''),
+                    'score': row.get('score'),  # None if no real score available
                 })
         return refs
 

--- a/packages/shared-python/shared/services/retrieval/agentic/navigation/document.py
+++ b/packages/shared-python/shared/services/retrieval/agentic/navigation/document.py
@@ -39,10 +39,8 @@ from shared.services.retrieval.agentic.navigation.selection_hydration import (
     hydrate_path_selections_into_node,
 )
 from shared.services.retrieval.agentic.discovery.selection import (
-    _find_covering_path,
     DiscoverySelectResult,
 )
-from shared.services.retrieval.search.lexical_text import normalize_section_path
 from shared.services.retrieval.llm_adapter import LLMFn
 
 

--- a/packages/shared-python/shared/services/retrieval/agentic/navigation/document.py
+++ b/packages/shared-python/shared/services/retrieval/agentic/navigation/document.py
@@ -39,8 +39,10 @@ from shared.services.retrieval.agentic.navigation.selection_hydration import (
     hydrate_path_selections_into_node,
 )
 from shared.services.retrieval.agentic.discovery.selection import (
+    _find_covering_path,
     DiscoverySelectResult,
 )
+from shared.services.retrieval.search.lexical_text import normalize_section_path
 from shared.services.retrieval.llm_adapter import LLMFn
 
 

--- a/packages/shared-python/shared/services/retrieval/execution/plan.py
+++ b/packages/shared-python/shared/services/retrieval/execution/plan.py
@@ -275,7 +275,7 @@ def _log_retrieval_complete(
             source = result.get("source", {})
             logger.info(
                 f"    [{index + 1}] type={result.get('chunk_type', '?')}  "
-                f"score={result.get('score', 0):.4f}"
+                f"score={result.get('score') or 0.0:.4f}"
                 f"  path={source.get('section_path', '')}"
                 f"  file={source.get('source_file_name', '')}"
             )

--- a/packages/shared-python/shared/services/retrieval/execution/reference_resolver.py
+++ b/packages/shared-python/shared/services/retrieval/execution/reference_resolver.py
@@ -24,6 +24,7 @@ async def resolve_workflow_references(
     user_id: str,
     namespace: str,
     refs: list[dict[str, Any]],
+    score_by_chunk_id: dict[str, float] | None = None,
 ) -> ResolvedWorkflowReferences:
     enriched_refs = await enrich_referenced_chunks_with_asset_urls(refs)
     hydrated_rows = await hydrate_referenced_chunk_rows(
@@ -31,6 +32,7 @@ async def resolve_workflow_references(
         user_id=user_id,
         namespace=namespace,
         refs=enriched_refs,
+        score_by_chunk_id=score_by_chunk_id,
     )
     return _select_matching_references(enriched_refs, hydrated_rows)
 

--- a/packages/shared-python/shared/services/retrieval/execution/routes.py
+++ b/packages/shared-python/shared/services/retrieval/execution/routes.py
@@ -115,12 +115,57 @@ async def _run_agentic_route(
         request=WorkflowRunRequest.from_route_context(context),
     )
 
+    # Build a real score index for hydration:
+    # 1. Discovery RRF score — available for chunks that surfaced in the
+    #    3-channel BM25 pass (stored in each referenced_chunk as 'score').
+    # 2. KG document confidence — LLM-assigned confidence per selected document
+    #    (stored in decision_trace kg_select entry), used as a fallback for
+    #    chunks that were only found through navigation (no discovery score).
+    score_by_chunk_id: dict[str, float] = {}
+
+    # Layer 1: referenced_chunk-level score (propagated from discovery rows)
+    for ref in workflow_result.referenced_chunks:
+        cid = ref.get('chunk_id', '')
+        raw_score = ref.get('score')
+        if cid and raw_score is not None:
+            try:
+                score_by_chunk_id[cid] = float(raw_score)
+            except (TypeError, ValueError):
+                pass
+
+    # Layer 2: per-document KG confidence as default for navigation-only chunks.
+    # Each step's decision_trace contains a 'kg_select' phase entry that holds
+    # the LLM-assigned confidence score per selected document.
+    doc_confidence: dict[str, float] = {}
+    for step in workflow_result.steps:
+        for entry in step.decision_trace or []:
+            if entry.get('phase') == 'kg_select':
+                for doc_info in entry.get('documents', []):
+                    doc_id = doc_info.get('document_id', '')
+                    conf = doc_info.get('confidence')
+                    if doc_id and conf is not None:
+                        try:
+                            doc_confidence[doc_id] = float(conf)
+                        except (TypeError, ValueError):
+                            pass
+
     resolved_references = await resolve_workflow_references(
         db=context.db,
         user_id=context.user_id,
         namespace=context.namespace,
         refs=workflow_result.referenced_chunks,
+        score_by_chunk_id=score_by_chunk_id if score_by_chunk_id else None,
     )
+
+    # Backfill doc-level confidence for chunks that have no discovery score
+    if doc_confidence:
+        for row in resolved_references.rows:
+            cid = row.get('chunk_id', '')
+            if cid and row.get('score') is None:
+                doc_id = row.get('document_id', '')
+                if doc_id in doc_confidence:
+                    row['score'] = doc_confidence[doc_id]
+
     assembled_workflow_rows = await assemble_retrieval_results(
         db=context.db,
         rows=resolved_references.rows,

--- a/packages/shared-python/shared/services/retrieval/hydration/reference.py
+++ b/packages/shared-python/shared/services/retrieval/hydration/reference.py
@@ -19,6 +19,7 @@ async def hydrate_referenced_chunk_rows(
     user_id: str,
     namespace: str,
     refs: list[dict[str, Any]],
+    score_by_chunk_id: dict[str, float] | None = None,
 ) -> list[dict[str, Any]]:
     if db is None or not refs:
         return []
@@ -67,7 +68,14 @@ async def hydrate_referenced_chunk_rows(
             'source_file_name': document.source_file_name,
             'chunk_type': chunk.chunk_type,
             'content': chunk.content,
-            'score': 1.0,
+            # Use the caller-supplied score when available (e.g. discovery RRF or
+            # KG confidence). None signals "no score known" so consumers can
+            # distinguish unscored chunks from genuinely high-scoring ones.
+            'score': (
+                score_by_chunk_id.get(chunk.chunk_id)
+                if score_by_chunk_id is not None
+                else None
+            ),
             'file_path': chunk.file_path,
             'chunk_metadata': chunk.chunk_metadata or {},
             'job_result_id': chunk.job_result_id,


### PR DESCRIPTION
## Summary

Agentic retrieval results previously returned a hardcoded `score: 1.0` for every chunk in `results[]`, making the score field meaningless for consumers (Notebook, SDKs). This PR fixes the full pipeline so that real scores flow through to the final response.

## Root Cause

`hydrate_referenced_chunk_rows` in `hydration/reference.py` re-fetched chunks from the database after the agentic navigation phase, but the database row has no search-time score — so it defaulted to `1.0`. The discovery RRF scores and KG confidence scores were computed earlier but never threaded through to this hydration step.

## Changes

### `hydration/reference.py`
- Added optional `score_by_chunk_id: dict[str, float] | None` parameter to `hydrate_referenced_chunk_rows`
- `score` is now `None` (not `1.0`) when no real score is available, so consumers can distinguish unscored chunks from genuinely high-scoring ones

### `agentic/core/types.py`
- `collect_referenced_ids` now propagates `score` from hydrated leaf rows into the referenced chunk records
- Return type widened from `list[dict[str, str]]` to `list[dict[str, Any]]` to accommodate the float score field

### `execution/reference_resolver.py`
- Threads the new `score_by_chunk_id` parameter through to `hydrate_referenced_chunk_rows`

### `execution/routes.py` — `_run_agentic_route`
Two-layer score injection:
- **Layer 1**: Discovery RRF score — read from `referenced_chunks[].score` (propagated from `collect_referenced_ids`)
- **Layer 2**: KG document confidence — read from `step.decision_trace` `kg_select` phase entries, used as a per-document fallback for chunks found only through navigation
- Backfill guard changed from `== 1.0` to `is None` to avoid false positives on genuinely scored chunks

## Quality

- `make lint`: ✅ All checks passed
- `make typecheck`: ✅ 0 errors, 0 warnings