### PR TITLE
Productionize oversized PDF sharding

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -91,8 +91,11 @@ ARK_API_KEY=
 
 # File handling defaults
 SUPPORTED_EXTENSIONS=.doc,.docx,.pdf,.txt,.xls,.xlsx,.csv,.pptx,.jpg,.jpeg,.png,.md
-MAX_FILE_SIZE=104857600
-MAX_PDF_PAGE_LIMIT=600
+MAX_FILE_SIZE=314572800
+MAX_PDF_PAGE_LIMIT=200
+OVERSIZED_PDF_SHARD_ENABLED=true
+OVERSIZED_PDF_SOFT_LIMIT=1500
+MINERU_SHARD_CONCURRENCY=3
 
 # Required for specific features: webhooks and callbacks
 WEBHOOK_MASTER_KEY=

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -116,8 +116,11 @@ ILOVEAPI_SECRET_KEY=
 
 # File handling defaults
 SUPPORTED_EXTENSIONS=.doc,.docx,.pdf,.txt,.xls,.xlsx,.csv,.pptx,.jpg,.jpeg,.png,.md
-MAX_FILE_SIZE=104857600
-MAX_PDF_PAGE_LIMIT=600
+MAX_FILE_SIZE=314572800
+MAX_PDF_PAGE_LIMIT=200
+OVERSIZED_PDF_SHARD_ENABLED=true
+OVERSIZED_PDF_SOFT_LIMIT=1500
+MINERU_SHARD_CONCURRENCY=3
 
 # Legacy parser compatibility fields.
 # ALL_DF_COLS=content,path,type,length,keywords,summary,know_id,tokens,connectto,addtime,page_nums

--- a/apps/worker/app/services/document_ingestion/file_size_policy.py
+++ b/apps/worker/app/services/document_ingestion/file_size_policy.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+SUPPORT_EMAIL = "team@knowhereto.ai"
+ISSUES_URL = "https://github.com/Ontos-AI/knowhere/issues"
+
+
+def build_file_size_limit_message(*, limit_mb: int, file_extension: str) -> str:
+    return (
+        f"File size exceeds the {limit_mb}MB limit for "
+        f"{file_extension or 'this file'}. For larger files, contact "
+        f"{SUPPORT_EMAIL} or open an issue at {ISSUES_URL}."
+    )

--- a/apps/worker/app/services/document_ingestion/processing_run.py
+++ b/apps/worker/app/services/document_ingestion/processing_run.py
@@ -23,9 +23,11 @@ from app.services.document_ingestion.success_finalization import finalize_parse_
 from app.services.document_ingestion.workspace import (
     TemporaryParseWorkspace,
 )
+from app.services.document_parser.orchestration.oversized_pdf_policy import (
+    build_oversized_pdf_rejection,
+)
 from loguru import logger
 
-from shared.core.exceptions.domain_exceptions import ValidationException, Violation
 from shared.services.jobs.lifecycle.service import get_sync_job_lifecycle_service
 from shared.services.redis.distributed_lock import RedisJobLock
 from shared.services.redis.redis_sync_service import (
@@ -93,11 +95,11 @@ def _run_parse_job(
     )
 
     processing_started_at = datetime.now(timezone.utc)
-    if _is_pdf_page_limit_exceeded(
+    oversized_pdf_rejection = build_oversized_pdf_rejection(
         file_extension=prepared_source.file_extension,
         page_count=page_count,
-    ):
-        violations = _build_pdf_page_limit_violations(page_count)
+    )
+    if oversized_pdf_rejection is not None:
         billing_snapshot = record_skipped_parse_job_billing(
             job_id=job_id,
             workload_estimate=workload_estimate,
@@ -108,9 +110,9 @@ def _run_parse_job(
             billing_snapshot=billing_snapshot,
             processing_started_at=processing_started_at,
             workload_estimate=workload_estimate,
-            extra_metadata={"error_details": {"violations": violations}},
+            extra_metadata={"error_details": oversized_pdf_rejection.details},
         )
-        _raise_pdf_page_limit_exceeded(page_count, violations)
+        raise oversized_pdf_rejection
 
     billing_snapshot = charge_parse_job_pages(
         job_id=job_id,
@@ -161,37 +163,4 @@ def _run_parse_job(
         processing_started_at=processing_started_at,
         task_workspace_dir=task_workspace.root_dir,
         result_storage_factory=get_result_storage,
-    )
-
-
-def _is_pdf_page_limit_exceeded(*, file_extension: str, page_count: int) -> bool:
-    from shared.core.config import settings
-
-    return file_extension == ".pdf" and page_count > settings.MAX_PDF_PAGE_LIMIT
-
-
-def _build_pdf_page_limit_violations(page_count: int) -> list[Violation]:
-    from shared.core.config import settings
-
-    pdf_page_limit = settings.MAX_PDF_PAGE_LIMIT
-    return [
-        {
-            "field": "page_count",
-            "description": f"PDF has {page_count} pages, limit is {pdf_page_limit}",
-        }
-    ]
-
-
-def _raise_pdf_page_limit_exceeded(
-    page_count: int, violations: list[Violation]
-) -> None:
-    from shared.core.config import settings
-
-    pdf_page_limit = settings.MAX_PDF_PAGE_LIMIT
-    raise ValidationException(
-        user_message=(
-            f"Document too large: {page_count} pages exceeds the {pdf_page_limit}-page limit. "
-            "Please split the document and upload in smaller batches."
-        ),
-        violations=violations,
     )

--- a/apps/worker/app/services/document_ingestion/source_preparation.py
+++ b/apps/worker/app/services/document_ingestion/source_preparation.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+from app.services.document_ingestion.file_size_policy import (
+    build_file_size_limit_message,
+)
 from app.services.document_ingestion.processing_context import ParseJobContext
 from app.services.document_parser.support.internal_parse_name import (
     prepare_internal_parse_input,
@@ -89,7 +92,10 @@ def _assert_source_file_within_size_limit(
     if file_size > settings.MAX_FILE_SIZE:
         limit_mb = settings.MAX_FILE_SIZE // (1024 * 1024)
         raise ValidationException(
-            user_message=f"File size exceeds limit (max {limit_mb}MB for {file_extension})",
+            user_message=build_file_size_limit_message(
+                limit_mb=limit_mb,
+                file_extension=file_extension,
+            ),
             violations=[
                 {
                     "field": "file_size",

--- a/apps/worker/app/services/document_parser/formats/pdf/parser.py
+++ b/apps/worker/app/services/document_parser/formats/pdf/parser.py
@@ -2,6 +2,9 @@
 import os
 
 from app.services.document_parser.formats.markdown.parser import parse_md
+from app.services.document_parser.orchestration.oversized_pdf_policy import (
+    build_oversized_pdf_processing_failed_exception,
+)
 from app.services.document_parser.providers.mineru.pdf_service import parse_via_full
 from app.services.document_parser.support.stage_profiler import stage_timer
 from loguru import logger
@@ -36,10 +39,21 @@ def parse_pdfs(
             f"📄 Oversized PDF: {profile.page_count} pages > "
             f"{settings.MAX_PDF_PAGE_LIMIT} limit, entering shard pipeline"
         )
-        return _parse_oversized_pdf(
-            pdf_path, filename, output_dir, base_llm_paras,
-            profile=profile, relative_root=relative_root, s3_key=s3_key,
-        )
+        try:
+            return _parse_oversized_pdf(
+                pdf_path, filename, output_dir, base_llm_paras,
+                profile=profile, relative_root=relative_root, s3_key=s3_key,
+            )
+        except Exception as exc:
+            logger.exception(
+                "Oversized PDF shard pipeline failed for {} (pages={})",
+                filename,
+                profile.page_count,
+            )
+            raise build_oversized_pdf_processing_failed_exception(
+                page_count=profile.page_count,
+                original_exception=exc,
+            ) from exc
 
     # ── Standard single-pass MinerU ──
     logger.info(f"📄 Standard MinerU parse for {filename} [route={route}]")
@@ -173,8 +187,7 @@ def _parse_oversized_pdf(
         """Run full heading prediction pipeline on a single shard's full.md."""
         md_path = os.path.join(shard_out_dir, "full.md")
         if not os.path.exists(md_path):
-            logger.warning(f"shard_{shard_idx}: full.md not found, returning empty")
-            return ShardHeadingResult(shard_index=shard_idx, lines_with_heading=[], heading_count=0)
+            raise FileNotFoundError(f"shard_{shard_idx}: full.md not found")
 
         with open(md_path, "r", encoding="utf-8") as f:
             md_lines = f.readlines()
@@ -227,19 +240,21 @@ def _parse_oversized_pdf(
                 shard_heading_results[idx] = future.result()
 
     # 7. Merge: concatenate lines_with_heading (in shard order) + merge images
+    complete_heading_results: list[ShardHeadingResult] = []
+    for index, result in enumerate(shard_heading_results):
+        if result is None:
+            raise RuntimeError(f"Missing heading result for shard_{index}")
+        complete_heading_results.append(result)
+
     all_lines_with_heading: list[str] = merge_shard_lines(
-        [
-            result.lines_with_heading
-            for result in shard_heading_results
-            if result is not None
-        ]
+        [result.lines_with_heading for result in complete_heading_results]
     )
     total_headings = sum(
         1 for line in all_lines_with_heading if line.startswith("#")
     )
 
     logger.info(
-        f"📎 Merged {len(shard_heading_results)} shards: "
+        f"📎 Merged {len(complete_heading_results)} shards: "
         f"{len(all_lines_with_heading)} lines, {total_headings} headings"
     )
 

--- a/apps/worker/app/services/document_parser/orchestration/oversized_pdf_policy.py
+++ b/apps/worker/app/services/document_parser/orchestration/oversized_pdf_policy.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from shared.core.config import settings
+from shared.core.exceptions.domain_exceptions import (
+    PDFParsingException,
+    ValidationException,
+    Violation,
+)
+
+
+def build_oversized_pdf_rejection(
+    *,
+    file_extension: str,
+    page_count: int,
+) -> ValidationException | None:
+    """Return the pre-parse oversized PDF rejection, if this file must be blocked."""
+    if file_extension.lower() != ".pdf":
+        return None
+    if page_count <= settings.MAX_PDF_PAGE_LIMIT:
+        return None
+    if not settings.OVERSIZED_PDF_SHARD_ENABLED:
+        return _build_standard_page_limit_exception(page_count)
+    if page_count > settings.OVERSIZED_PDF_SOFT_LIMIT:
+        return _build_soft_limit_exception(page_count)
+    return None
+
+
+def raise_if_oversized_pdf_not_supported(*, page_count: int) -> None:
+    rejection = build_oversized_pdf_rejection(
+        file_extension=".pdf",
+        page_count=page_count,
+    )
+    if rejection is not None:
+        raise rejection
+
+
+def build_oversized_pdf_processing_failed_exception(
+    *,
+    page_count: int,
+    original_exception: Exception,
+) -> PDFParsingException:
+    reason = _format_original_error(original_exception)
+    page_limit = settings.MAX_PDF_PAGE_LIMIT
+    user_message = (
+        "Oversized PDF processing failed during sharding: "
+        f"{reason}. This document has {page_count} pages and exceeds the "
+        f"{page_limit}-page direct processing limit, so it cannot be processed "
+        "without a successful shard pipeline."
+    )
+    return PDFParsingException(
+        user_message=user_message,
+        reason="OVERSIZED_SHARD_PIPELINE_FAILED",
+        internal_message=(
+            "Oversized PDF shard pipeline failed; falling back to page-limit "
+            f"rejection. page_count={page_count}, limit={page_limit}, "
+            f"original={type(original_exception).__name__}: {original_exception}"
+        ),
+        original_exception=original_exception,
+    )
+
+
+def _build_standard_page_limit_exception(page_count: int) -> ValidationException:
+    page_limit = settings.MAX_PDF_PAGE_LIMIT
+    return ValidationException(
+        user_message=(
+            f"Document too large: {page_count} pages exceeds the {page_limit}-page "
+            "limit. Please split the document and upload it in smaller parts."
+        ),
+        violations=[_page_limit_violation(page_count, page_limit)],
+    )
+
+
+def _build_soft_limit_exception(page_count: int) -> ValidationException:
+    soft_limit = settings.OVERSIZED_PDF_SOFT_LIMIT
+    return ValidationException(
+        user_message=(
+            f"This document has {page_count} pages. Processing ultra-long documents "
+            f"over {soft_limit} pages requires dedicated resources. Please contact "
+            "support for assistance."
+        ),
+        violations=[{
+            "field": "page_count",
+            "description": f"PDF has {page_count} pages, soft limit is {soft_limit}",
+        }],
+    )
+
+
+def _page_limit_violation(page_count: int, page_limit: int) -> Violation:
+    return {
+        "field": "page_count",
+        "description": f"PDF has {page_count} pages, limit is {page_limit}",
+    }
+
+
+def _format_original_error(exc: Exception) -> str:
+    user_message = getattr(exc, "user_message", None)
+    if isinstance(user_message, str) and user_message.strip():
+        return user_message.strip()
+    message = str(exc).strip()
+    if message:
+        return f"{type(exc).__name__}: {message}"
+    return type(exc).__name__

--- a/apps/worker/app/services/document_parser/orchestration/parse_session.py
+++ b/apps/worker/app/services/document_parser/orchestration/parse_session.py
@@ -9,12 +9,14 @@ from app.services.document_parser.orchestration.path_segment import (
     build_parser_path_segment,
 )
 from app.services.document_parser.orchestration.parse_input import ParseInput
+from app.services.document_parser.orchestration.oversized_pdf_policy import (
+    raise_if_oversized_pdf_not_supported,
+)
 from app.services.document_parser.profiling.doc_profiler import profile_document
 from app.services.document_parser.support.stage_profiler import stage_timer
 from loguru import logger
 
 from shared.core.config import settings
-from shared.core.exceptions.domain_exceptions import ValidationException
 
 
 @dataclass(frozen=True)
@@ -110,36 +112,7 @@ def build_parse_session(parse_input: ParseInput) -> ParseSession:
             )
 
     if profile.file_type == "pdf" and profile.page_count > settings.MAX_PDF_PAGE_LIMIT:
-        if profile.page_count > settings.OVERSIZED_PDF_SOFT_LIMIT:
-            raise ValidationException(
-                user_message=(
-                    f"This document has {profile.page_count} pages. Processing ultra-long "
-                    f"documents (over {settings.OVERSIZED_PDF_SOFT_LIMIT} pages) requires "
-                    "dedicated resources. Please contact our support team for assistance."
-                ),
-                violations=[{
-                    "field": "page_count",
-                    "description": (
-                        f"PDF has {profile.page_count} pages, "
-                        f"soft limit is {settings.OVERSIZED_PDF_SOFT_LIMIT}"
-                    ),
-                }],
-            )
-        if not settings.OVERSIZED_PDF_SHARD_ENABLED:
-            raise ValidationException(
-                user_message=(
-                    f"Document has {profile.page_count} pages, exceeding the "
-                    f"{settings.MAX_PDF_PAGE_LIMIT}-page limit. Please split the "
-                    "document into smaller parts and upload them separately."
-                ),
-                violations=[{
-                    "field": "page_count",
-                    "description": (
-                        f"PDF has {profile.page_count} pages, "
-                        f"limit is {settings.MAX_PDF_PAGE_LIMIT}"
-                    ),
-                }],
-            )
+        raise_if_oversized_pdf_not_supported(page_count=profile.page_count)
 
     if profile.doc_category == "atlas":
         filename, internal_output_filename, relative_root, full_output_dir = (

--- a/apps/worker/app/services/workload/url_upload_transfer.py
+++ b/apps/worker/app/services/workload/url_upload_transfer.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import os
 
+from app.services.document_ingestion.file_size_policy import (
+    build_file_size_limit_message,
+)
 from loguru import logger
 
 from shared.core.config import settings
@@ -63,7 +66,10 @@ def assert_temp_file_within_size_limit(
 
     limit_mb = settings.MAX_FILE_SIZE // (1024 * 1024)
     raise ValidationException(
-        user_message=f"File size exceeds limit (max {limit_mb}MB for {file_extension})",
+        user_message=build_file_size_limit_message(
+            limit_mb=limit_mb,
+            file_extension=file_extension,
+        ),
         violations=[
             {
                 "field": "file_size",

--- a/apps/worker/tests/contract/test_parse_task_contract.py
+++ b/apps/worker/tests/contract/test_parse_task_contract.py
@@ -386,6 +386,7 @@ def test_should_reject_pdf_when_page_count_exceeds_configured_limit(
     _write_blank_pdf(pdf_path, actual_page_count)
 
     contract.use_pdf_page_limit(monkeypatch, max_pdf_page_limit)
+    contract.use_oversized_pdf_shard_enabled(monkeypatch, enabled=False)
     job = contract.create_file_job(
         source_file_name=source_file_name,
         job_id_prefix="job_pdf_page_limit",
@@ -416,7 +417,7 @@ def test_should_reject_pdf_when_page_count_exceeds_configured_limit(
     assert job_row["error_code"] == "INVALID_ARGUMENT"
     assert (
         job_row["error_message"]
-        == "Document too large: 2 pages exceeds the 1-page limit. Please split the document and upload in smaller batches."
+        == "Document too large: 2 pages exceeds the 1-page limit. Please split the document and upload it in smaller parts."
     )
     assert metadata["error_details"] == {
         "violations": [
@@ -432,3 +433,244 @@ def test_should_reject_pdf_when_page_count_exceeds_configured_limit(
     assert billing["transaction_types"] == []
     assert billing["transaction_counts"] == {}
     assert billing["system_grant_payment_count"] == 0
+
+
+def test_should_reject_pdf_when_page_count_exceeds_soft_limit(
+    worker_contract_environment: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    contract = WorkerParseContract.create()
+    contract.use_workspace_root(monkeypatch, tmp_path)
+    contract.use_billing(monkeypatch, is_enabled=True)
+
+    max_pdf_page_limit = 1
+    soft_limit = 2
+    actual_page_count = 3
+    source_file_name = "ultra-long-contract.pdf"
+    pdf_path = tmp_path / source_file_name
+    _write_blank_pdf(pdf_path, actual_page_count)
+
+    contract.use_pdf_page_limit(monkeypatch, max_pdf_page_limit)
+    contract.use_oversized_pdf_soft_limit(monkeypatch, soft_limit)
+    contract.use_oversized_pdf_shard_enabled(monkeypatch, enabled=True)
+    job = contract.create_file_job(
+        source_file_name=source_file_name,
+        job_id_prefix="job_pdf_soft_limit",
+    )
+    contract.upload_source_file(local_file_path=pdf_path, s3_key=job["s3_key"])
+
+    celery_result = contract.enqueue_parse_task(
+        job_id=job["job_id"],
+        user_id=job["user_id"],
+    )
+
+    assert celery_result.failed()
+    metadata = contract.get_job_metadata(job["job_id"])
+    job_row = contract.observe_job_status(job["job_id"])
+
+    assert job_row["status"] == "failed"
+    assert job_row["billing_status"] == "skipped"
+    assert job_row["credits_charged"] == 0
+    assert job_row["error_code"] == "INVALID_ARGUMENT"
+    assert (
+        job_row["error_message"]
+        == "This document has 3 pages. Processing ultra-long documents over 2 pages requires dedicated resources. Please contact support for assistance."
+    )
+    assert metadata["error_details"] == {
+        "violations": [
+            {
+                "field": "page_count",
+                "description": "PDF has 3 pages, soft limit is 2",
+            }
+        ]
+    }
+
+
+def test_oversized_pdf_shard_failure_preserves_processing_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+    monkeypatch.setenv("TMP_PATH", str(tmp_path))
+    monkeypatch.setenv("S3_BUCKET_NAME", "test-uploads")
+    monkeypatch.setenv("S3_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("S3_SECRET_ACCESS_KEY", "test")
+    monkeypatch.setenv("S3_TEMP_PATH", str(tmp_path))
+
+    from app.services.document_parser.formats.pdf import parser as pdf_parser
+    from shared.core.exceptions.domain_exceptions import PDFParsingException
+
+    class _Profile:
+        route = "standard"
+        doc_category = "generic"
+        page_count = 2
+
+    monkeypatch.setattr(pdf_parser.settings, "MAX_PDF_PAGE_LIMIT", 1)
+
+    def _fail_oversized_parse(*args, **kwargs):
+        raise RuntimeError("MinerU shard 0 failed")
+
+    monkeypatch.setattr(pdf_parser, "_parse_oversized_pdf", _fail_oversized_parse)
+
+    with pytest.raises(PDFParsingException) as exc_info:
+        pdf_parser.parse_pdfs(
+            str(tmp_path / "source.pdf"),
+            "source.pdf",
+            str(tmp_path),
+            {},
+            profile=_Profile(),
+        )
+
+    assert exc_info.value.details["reason"] == "OVERSIZED_SHARD_PIPELINE_FAILED"
+    assert "MinerU shard 0 failed" in exc_info.value.user_message
+    assert "exceeds the 1-page direct processing limit" in exc_info.value.user_message
+
+
+def test_oversized_pdf_happy_path_uses_shard_pipeline_without_external_services(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+    monkeypatch.setenv("TMP_PATH", str(tmp_path))
+    monkeypatch.setenv("S3_BUCKET_NAME", "test-uploads")
+    monkeypatch.setenv("S3_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("S3_SECRET_ACCESS_KEY", "test")
+    monkeypatch.setenv("S3_TEMP_PATH", str(tmp_path))
+
+    from app.services.document_agent.manifest import (
+        H1BoundaryResult,
+        PageAnatomyMap,
+        Shard,
+        ShardPlan,
+        TocResult,
+    )
+    from app.services.document_parser.formats.pdf import parser as pdf_parser
+
+    pdf_path = tmp_path / "oversized.pdf"
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    _write_blank_pdf(pdf_path, page_count=3)
+
+    class _Profile:
+        route = "standard"
+        doc_category = "generic"
+        page_count = 3
+
+    calls: dict[str, object] = {}
+
+    def _fake_run_doc_agent(pdf_path_arg: str, job_id: str, output_dir: str):
+        calls["doc_agent"] = {
+            "pdf_path": pdf_path_arg,
+            "job_id": job_id,
+            "output_dir": output_dir,
+        }
+        return PageAnatomyMap(
+            job_id=job_id,
+            file_path=pdf_path_arg,
+            page_count=3,
+            page_features=[],
+            page_labels=[],
+            toc_result=TocResult(toc_pages=[1], method="vlm_batch"),
+            h1_result=H1BoundaryResult(method="toc_grep"),
+            shard_plan=ShardPlan(
+                enabled=True,
+                reason="too_large",
+                shards=[
+                    Shard(
+                        shard_index=0,
+                        page_start=1,
+                        page_end=2,
+                        page_offset=0,
+                        anchor_type="h1_boundary",
+                        anchor_evidence="Chapter 1",
+                        confidence=0.9,
+                    ),
+                    Shard(
+                        shard_index=1,
+                        page_start=3,
+                        page_end=3,
+                        page_offset=2,
+                        anchor_type="h1_boundary",
+                        anchor_evidence="Chapter 2",
+                        confidence=0.9,
+                    ),
+                ],
+            ),
+            toc_hierarchies=[{"toc_tree": {"Chapter 1": {}, "Chapter 2": {}}}],
+        )
+
+    def _fake_split_pdf(pdf_path_arg, shards, work_dir, exclude_pages=None):
+        calls["exclude_pages"] = exclude_pages
+        paths = []
+        for shard in shards:
+            shard_path = Path(work_dir) / f"shard_{shard.shard_index}.pdf"
+            shard_path.write_bytes(b"%PDF-1.4\n%%EOF\n")
+            paths.append(str(shard_path))
+        return paths, None
+
+    def _fake_parse_via_full(shard_pdf, shard_filename, shard_out, s3_key=None):
+        shard_index = 0 if "shard0" in shard_filename else 1
+        lines_by_shard = {
+            0: ["# Chapter 1", "Shard one body."],
+            1: ["# Chapter 2", "Shard two body."],
+        }
+        Path(shard_out).mkdir(parents=True, exist_ok=True)
+        (Path(shard_out) / "full.md").write_text(
+            "\n".join(lines_by_shard[shard_index]),
+            encoding="utf-8",
+        )
+
+    def _identity_eval_md_headings(
+        md_lines,
+        source_type,
+        toc_hierarchies=None,
+        smart_parse=True,
+        model_name=None,
+        output_dir=None,
+        layout_json_path=None,
+    ):
+        calls.setdefault("heading_dirs", []).append(output_dir)
+        return list(md_lines)
+
+    monkeypatch.setattr(pdf_parser.settings, "MAX_PDF_PAGE_LIMIT", 2)
+    monkeypatch.setattr(pdf_parser.settings, "MINERU_SHARD_CONCURRENCY", 1)
+    monkeypatch.setattr(
+        "app.services.document_parser.formats.pdf.shard_splitter.run_doc_agent",
+        _fake_run_doc_agent,
+    )
+    monkeypatch.setattr(
+        "app.services.document_parser.formats.pdf.shard_splitter.split_pdf",
+        _fake_split_pdf,
+    )
+    monkeypatch.setattr(pdf_parser, "parse_via_full", _fake_parse_via_full)
+    monkeypatch.setattr(
+        "app.services.document_parser.formats.markdown.parser.eval_md_headings",
+        _identity_eval_md_headings,
+    )
+
+    df = pdf_parser.parse_pdfs(
+        str(pdf_path),
+        "oversized.pdf",
+        str(output_dir),
+        {
+            "smart_title_parse": False,
+            "summary_image": False,
+            "summary_table": False,
+            "summary_txt": False,
+            "stopwords": [],
+            "model_name": "mock-model",
+            "hierarchy_model_name": "mock-model",
+        },
+        profile=_Profile(),
+        relative_root="oversized.pdf",
+    )
+
+    assert calls["exclude_pages"] == {1}
+    assert len(calls["heading_dirs"]) == 2
+    assert list(df["type"]) == ["PTXT", "PTXT"]
+    assert list(df["content"]) == ["Shard one body.", "Shard two body."]
+    assert list(df["path"]) == [
+        "oversized.pdf/Chapter 1",
+        "oversized.pdf/Chapter 2",
+    ]

--- a/apps/worker/tests/support/worker_parse_contract.py
+++ b/apps/worker/tests/support/worker_parse_contract.py
@@ -73,6 +73,40 @@ class WorkerParseContract:
                     raising=False,
                 )
 
+    def use_oversized_pdf_shard_enabled(
+        self,
+        monkeypatch: MonkeyPatch,
+        enabled: bool,
+    ) -> None:
+        monkeypatch.setenv("OVERSIZED_PDF_SHARD_ENABLED", "true" if enabled else "false")
+        monkeypatch.setattr(self.settings, "OVERSIZED_PDF_SHARD_ENABLED", enabled)
+        for loaded_module in list(sys.modules.values()):
+            module_settings = getattr(loaded_module, "settings", None)
+            if hasattr(module_settings, "OVERSIZED_PDF_SHARD_ENABLED"):
+                monkeypatch.setattr(
+                    module_settings,
+                    "OVERSIZED_PDF_SHARD_ENABLED",
+                    enabled,
+                    raising=False,
+                )
+
+    def use_oversized_pdf_soft_limit(
+        self,
+        monkeypatch: MonkeyPatch,
+        soft_limit: int,
+    ) -> None:
+        monkeypatch.setenv("OVERSIZED_PDF_SOFT_LIMIT", str(soft_limit))
+        monkeypatch.setattr(self.settings, "OVERSIZED_PDF_SOFT_LIMIT", soft_limit)
+        for loaded_module in list(sys.modules.values()):
+            module_settings = getattr(loaded_module, "settings", None)
+            if hasattr(module_settings, "OVERSIZED_PDF_SOFT_LIMIT"):
+                monkeypatch.setattr(
+                    module_settings,
+                    "OVERSIZED_PDF_SOFT_LIMIT",
+                    soft_limit,
+                    raising=False,
+                )
+
     def create_file_job(
         self,
         *,

--- a/packages/shared-python/shared/core/config/storage.py
+++ b/packages/shared-python/shared/core/config/storage.py
@@ -60,7 +60,7 @@ class StorageConfig(BaseModel):
 
     # File-handling limits.
     MAX_FILE_SIZE: int = Field(
-        default=104857600, description="Maximum file size in bytes"
+        default=314572800, description="Maximum file size in bytes"
     )
     MAX_PDF_PAGE_LIMIT: int = Field(
         default=200,
@@ -69,7 +69,7 @@ class StorageConfig(BaseModel):
         "Documents exceeding this trigger the shard pipeline when enabled.",
     )
     OVERSIZED_PDF_SHARD_ENABLED: bool = Field(
-        default=False,
+        default=True,
         description="Enable doc_agent shard pipeline for PDFs exceeding MAX_PDF_PAGE_LIMIT. "
         "When False, oversized PDFs are rejected.",
     )


### PR DESCRIPTION
## Summary
- Enable oversized PDF sharding by default through a centralized worker policy.
- Preserve explicit user-facing errors for oversized shard failures instead of silent partial extraction.
- Align backend file-size defaults with the 300MB upload limit and add support/issue guidance for oversized files.
- Add regression coverage for oversized PDF rejection, shard failure mapping, and a mocked happy path that avoids MinerU/LLM external calls.

## Test plan
- `uv run --project apps/worker python -m pytest apps/worker/tests/contract/test_parse_task_contract.py::test_oversized_pdf_shard_failure_preserves_processing_error apps/worker/tests/contract/test_parse_task_contract.py::test_oversized_pdf_happy_path_uses_shard_pipeline_without_external_services -q`
- `python -m py_compile apps/worker/app/services/document_ingestion/file_size_policy.py apps/worker/app/services/document_ingestion/source_preparation.py apps/worker/app/services/workload/url_upload_transfer.py apps/worker/tests/contract/test_parse_task_contract.py packages/shared-python/shared/core/config/storage.py apps/worker/app/services/document_parser/orchestration/oversized_pdf_policy.py`

Closes #121

Made with [Cursor](https://cursor.com)