### PR TITLE
fix(retrieval): make term-channel CJK scoring well-defined

### DIFF
--- a/packages/shared-python/shared/services/retrieval/search/channels.py
+++ b/packages/shared-python/shared/services/retrieval/search/channels.py
@@ -249,6 +249,27 @@ async def _bm25_channel(
     return ranked_rows[:top_k]
 
 
+def _score_term_match(query_lower: str, query_tokens: list[str], haystack: str) -> float:
+    """Score one term-channel row.
+
+    Returns 0.0 when no token in `query_tokens` appears in `haystack`.
+    Otherwise returns a smooth log-scaled score in `[1.0, 1.0 + 0.5 * sqrt(N))]`
+    where N is the number of matching tokens.
+
+    A previous implementation gave 100.0 for the
+    `query_lower in haystack` branch, but that branch was unreachable for
+    CJK content: `term_search_text` is jieba-segmented, so the raw query
+    string is never a contiguous substring of the haystack. The smooth
+    scale keeps the ranking well-defined for every language.
+    """
+    if not query_tokens:
+        return 0.0
+    hit_count = sum(1 for u in query_tokens if u in haystack)
+    if hit_count == 0:
+        return 0.0
+    return 1.0 + 0.5 * (hit_count ** 0.5)
+
+
 async def term_channel(
     db: AsyncSession,
     *,
@@ -312,14 +333,10 @@ async def term_channel(
     scored: list[dict[str, Any]] = []
     for row in rows:
         haystack = (row.get("term_search_text") or "").lower()
-        if query_lower in haystack:
-            row["score"] = 100.0
+        score = _score_term_match(query_lower, query_tokens, haystack)
+        if score > 0.0:
+            row["score"] = score
             scored.append(row)
-        else:
-            hit_count = sum(1 for u in query_tokens if u in haystack)
-            if hit_count > 0:
-                row["score"] = float(hit_count)
-                scored.append(row)
 
     scored.sort(key=lambda r: r["score"], reverse=True)
     return scored[:top_k]

--- a/tests/services/retrieval/test_term_channel_scoring.py
+++ b/tests/services/retrieval/test_term_channel_scoring.py
@@ -1,0 +1,62 @@
+"""Unit tests for the term-channel scoring helper.
+
+The previous 100.0 boost for `query_lower in haystack` was unreachable
+for CJK content because `term_search_text` is jieba-segmented. The
+helper now uses a smooth log-scale that works for every language.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(ROOT / "packages" / "shared-python"))
+
+channels = importlib.import_module("shared.services.retrieval.search.channels")
+_score_term_match = channels._score_term_match
+
+
+def test_no_tokens_returns_zero():
+    assert _score_term_match("foo bar", [], "foo bar baz") == 0.0
+
+
+def test_no_match_returns_zero():
+    assert _score_term_match("foo bar", ["foo", "bar"], "baz qux") == 0.0
+
+
+def test_single_match_scores_above_one():
+    score = _score_term_match("施工", ["施工"], "施工现场 安全 规范")
+    assert 1.0 < score < 2.0
+
+
+def test_more_hits_score_higher():
+    one = _score_term_match("alpha beta", ["alpha", "beta"], "alpha delta")
+    two = _score_term_match("alpha beta", ["alpha", "beta"], "alpha beta delta")
+    three = _score_term_match("alpha beta", ["alpha", "beta", "gamma"], "alpha beta gamma")
+    assert one < two
+    assert two < three
+
+
+def test_cjk_multi_token_score_is_well_defined():
+    """Regression for the unreachable 100.0 branch.
+
+    All three CJK tokens appear in the haystack (separated by jieba
+    spaces in production). Score must be above 1.0 and bounded.
+    """
+    score = _score_term_match("施工 安全 规范", ["施工", "安全", "规范"], "施工 安全 规范 守则")
+    assert score > 1.0
+    assert score < 5.0
+
+
+def test_score_matches_within_query_tokens():
+    a = _score_term_match("foo", ["foo"], "foo bar")
+    b = _score_term_match("foo", ["FOO"], "foo bar")
+    # The function expects already-lowered tokens (callers pass
+    # tokenize_query_for_ranker output, which is lowered).
+    assert a > 0
+    # Tokens passed in raw case may not match — that is the caller's
+    # responsibility, not the helper's.
+    assert b == 0


### PR DESCRIPTION
fix(retrieval): make term-channel CJK scoring well-defined

`term_channel` had two branches: a 100.0 boost for `query_lower in
haystack`, and a per-token overlap counter. The substring branch was
unreachable for CJK content because `term_search_text` is
jieba-segmented — the raw query is never a contiguous substring of the
haystack, so Chinese/Japanese/Korean queries silently degenerated to
the noisy per-token counter while English queries got the 100.0 boost.

Extract the scoring into a `_score_term_match` helper that returns a
smooth log-scaled value `1.0 + 0.5 * sqrt(hit_count)` whenever any token
matches, and `0.0` otherwise. This keeps the ranking well-defined for
every language and removes a branch that was dead for the dominant
content of this project's corpus.

The 100.0 boost was a maintainer-facing constant, so the change is
intentionally narrow: no schema, no SQL, no API surface.

Adds `tests/services/retrieval/test_term_channel_scoring.py` covering:
- empty token list
- no token match
- single token match above 1.0 and below 2.0
- more hits score higher
- the CJK multi-token regression (3 jieba tokens in the haystack)
