### PR TITLE
docs: add ultra-long PDF parsing news

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ It ingests unstructured documents and produces persistent, navigable memory: par
 
 ## 📢 News
 
+- **June 1, 2026**: 📚 **Knowhere now supports ultra-long PDFs and atlas-style documents.** The parsing pipeline can process long-form PDFs with hundreds of pages (for example, 300, 500, or more) and route technical atlases or drawing collections through a dedicated layout-aware parser.
 - **May 7, 2026**: 🚀 **Knowhere is now Open Source!** We have open-sourced our entire stack for document ingestion, parsing, and agentic RAG. You can now self-host the full platform using [knowhere-self-hosted](https://github.com/Ontos-AI/knowhere-self-hosted). Check out our [Contribution Guide](CONTRIBUTING.md) to get involved!
 
 ## How it Works


### PR DESCRIPTION
## Summary

This PR updates the README News section with a June 1, 2026 product update for two user-facing parsing capabilities:

- Ultra-long PDF parsing for documents with hundreds of pages, such as 300, 500, or more pages.
- Atlas-style document parsing for technical atlases and drawing collections through a dedicated layout-aware parser.

## Rationale

The News section is a suitable place for important feature announcements that users can discover quickly from the repository landing page. Ultra-long PDF support and atlas parsing are high-impact document ingestion capabilities, so they should be visible alongside the existing open-source announcement.

## Testing

- make check
- git diff --check

## Scope

README-only documentation update. No runtime code changes.