### PR TITLE
Fix PR159 contract tests

### DIFF
--- a/apps/worker/tests/contract/test_document_agent_budget_contract.py
+++ b/apps/worker/tests/contract/test_document_agent_budget_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from types import SimpleNamespace
 
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 os.environ.setdefault("TMP_PATH", "/tmp/knowhere-test")
@@ -11,11 +12,9 @@ os.environ.setdefault("S3_TEMP_PATH", "/tmp")
 
 from app.services.document_agent.budget import BudgetTracker, StageEnvelope
 from app.services.page_memory import memory_service
-from shared.core.exceptions.domain_exceptions import ValidationException
 from shared.services.chunks.dataframe_chunk_converter import dataframe_to_chunks
 
 import pandas as pd
-import pytest
 
 
 def test_visual_stage_envelope_preserves_other_stage_guarantee() -> None:
@@ -90,12 +89,22 @@ def test_dataframe_converter_accepts_page_chunks_with_extra_metadata() -> None:
     assert chunks[0]["metadata"]["page_nums"] == [1, 2]
 
 
-def test_page_memory_unsupported_granularity_is_explicit() -> None:
-    with pytest.raises(ValidationException) as exc_info:
-        memory_service._raise_unsupported_granularity("page")  # noqa: SLF001
-
-    error = exc_info.value
-    assert "whole-document page memory" in error.user_message
-    assert "PAGE_MEMORY_GRANULARITY_NOT_IMPLEMENTED" in error.internal_message
-    assert error.violations[0]["field"] == "parse_track"
-    assert "granularity=page" in error.violations[0]["description"]
+def test_page_memory_granularity_routes_supported_page_modes() -> None:
+    assert (
+        memory_service._decide_granularity(  # noqa: SLF001
+            SimpleNamespace(page_count=6, toc=SimpleNamespace(has_toc=False))
+        )
+        == "whole_doc"
+    )
+    assert (
+        memory_service._decide_granularity(  # noqa: SLF001
+            SimpleNamespace(page_count=7, toc=SimpleNamespace(has_toc=False))
+        )
+        == "page"
+    )
+    assert (
+        memory_service._decide_granularity(  # noqa: SLF001
+            SimpleNamespace(page_count=201, toc=SimpleNamespace(has_toc=False))
+        )
+        == "shard_page"
+    )

--- a/apps/worker/tests/contract/test_parse_task_contract.py
+++ b/apps/worker/tests/contract/test_parse_task_contract.py
@@ -76,7 +76,10 @@ def test_parse_task_should_process_uploaded_file_through_real_contract_boundarie
     assert len(document_chunks) == len(job_chunks)
     assert observed["document_sections_count"] > 0
     assert all(row["chunk_type"] == "table" for row in job_chunks)
-    assert any("tables/" in str(row["path"]) for row in job_chunks)
+    assert any(
+        str((row["chunk_metadata"] or {}).get("file_path", "")).startswith("tables/")
+        for row in job_chunks
+    )
 
     assert contract.get_task_status(job["job_id"]) == "done"
     task_progress = contract.get_task_progress(job["job_id"])
@@ -100,7 +103,12 @@ def test_parse_task_should_process_uploaded_file_through_real_contract_boundarie
     assert len(chunks_payload["chunks"]) == len(job_chunks)
     assert all(chunk["type"] == "table" for chunk in chunks_payload["chunks"])
     assert any(
-        "Table summary:" in chunk["content"] for chunk in chunks_payload["chunks"]
+        chunk["content"].lstrip().startswith("<table")
+        for chunk in chunks_payload["chunks"]
+    )
+    assert any(
+        str(chunk["metadata"].get("summary", "")).startswith("table-")
+        for chunk in chunks_payload["chunks"]
     )
 
     manifest_payload = result_zip["manifest"]


### PR DESCRIPTION
## Summary
- Align page-memory contract coverage with PR159 page and shard-page support.
- Update Excel parse contract assertions to check table asset metadata and pure HTML persisted content.

## Test plan
- [x] uv run pytest apps/worker/tests/contract/test_document_agent_budget_contract.py::test_page_memory_granularity_routes_supported_page_modes apps/worker/tests/contract/test_parse_task_contract.py::test_parse_task_should_process_uploaded_file_through_real_contract_boundaries -q
- [x] uv run pytest apps/api/tests apps/worker/tests/contract -q


Made with [Cursor](https://cursor.com)