### PR TITLE
Fix PR 160 CodeQL comments

### DIFF
--- a/apps/worker/app/services/document_agent/structure/page_locate_agent.py
+++ b/apps/worker/app/services/document_agent/structure/page_locate_agent.py
@@ -89,7 +89,6 @@ class PageLocateResidualAgent:
         actual_max_depth = max_title_depth(nodes)
         emit_depth = min(actual_max_depth, self.config.max_emit_depth)
         emit_depth = max(emit_depth, self.config.min_emit_depth)
-        selected_nodes = nodes
         direct_matches: dict[tuple[str, ...], TitleMatch] = {}
         residuals: list[ResidualRequest] = []
 

--- a/apps/worker/app/services/document_parser/formats/excel/table_parser.py
+++ b/apps/worker/app/services/document_parser/formats/excel/table_parser.py
@@ -273,7 +273,6 @@ def _subtable_title_from_attrs(attrs: dict[str, Any]) -> str:
         subtable_index = int(attrs.get("subtable_index") or 1)
     except (TypeError, ValueError):
         subtable_count = 1
-        subtable_index = 1
     if subtable_count <= 1:
         return ""
     title = str(attrs.get("subtable_title") or "").strip()


### PR DESCRIPTION
## Summary
- remove the redundant `selected_nodes = nodes` assignment flagged by CodeQL
- remove the exception-path `subtable_index = 1` assignment that cannot be read before return

## Verification
- `uv run --all-packages --group lint ruff check apps/worker/app/services/document_agent/structure/page_locate_agent.py apps/worker/app/services/document_parser/formats/excel/table_parser.py`
- `python3 -m py_compile apps/worker/app/services/document_agent/structure/page_locate_agent.py apps/worker/app/services/document_parser/formats/excel/table_parser.py`
- `make lint`
- `make typecheck`
- `git diff --check`

Follow-up for PR #160 CodeQL review comments.