### PR TITLE
feat: page-based-4 heading hierarchy with preceding context and thinking toggle

### DIFF
--- a/apps/worker/app/services/document_agent/structure/page_locate_agent.py
+++ b/apps/worker/app/services/document_agent/structure/page_locate_agent.py
@@ -26,6 +26,12 @@ from app.services.document_agent.structure.page_locate_subagent import (
     SubAgentConfig,
 )
 
+VLM_CONFIRMED_DEFAULT_CONFIDENCE = 0.75
+GREP_ONLY_CONFIDENCE_CAP = 0.62
+RENDER_FAILED_GREP_CONFIDENCE_CAP = 0.58
+BUDGET_EXHAUSTED_GREP_CONFIDENCE_CAP = 0.56
+VLM_FAILED_GREP_CONFIDENCE_CAP = 0.54
+
 
 @dataclass(frozen=True)
 class PageLocateConfig:
@@ -248,7 +254,7 @@ def verify_section_page_choice(
         best = candidates[0]
         return {
             "selected_page": best.page,
-            "confidence": min(best.confidence, 0.62),
+            "confidence": min(best.confidence, GREP_ONLY_CONFIDENCE_CAP),
             "source": "agent_heuristic",
             "reason": "VLM unavailable; selected top grep candidate",
         }
@@ -267,7 +273,7 @@ def verify_section_page_choice(
         best = candidates[0]
         return {
             "selected_page": best.page,
-            "confidence": min(best.confidence, 0.58),
+            "confidence": min(best.confidence, RENDER_FAILED_GREP_CONFIDENCE_CAP),
             "source": "agent_heuristic",
             "reason": "render failed; selected top grep candidate",
         }
@@ -279,7 +285,7 @@ def verify_section_page_choice(
         best = candidates[0]
         return {
             "selected_page": best.page,
-            "confidence": min(best.confidence, 0.56),
+            "confidence": min(best.confidence, BUDGET_EXHAUSTED_GREP_CONFIDENCE_CAP),
             "source": "agent_heuristic",
             "reason": "page_locate visual budget exhausted; selected top grep candidate",
         }
@@ -323,7 +329,7 @@ def verify_section_page_choice(
             selected_page = None
         return {
             "selected_page": selected_page,
-            "confidence": float(payload.get("confidence") or 0.75),
+            "confidence": float(payload.get("confidence") or VLM_CONFIRMED_DEFAULT_CONFIDENCE),
             "source": "agent_vlm",
             "reason": str(payload.get("reason") or ""),
             "latency_ms": int((time.monotonic() - start) * 1000),
@@ -335,7 +341,7 @@ def verify_section_page_choice(
         logger.warning("[page_locate.agent] VLM failed for title={!r}: {}", title, exc)
         return {
             "selected_page": best.page,
-            "confidence": min(best.confidence, 0.54),
+            "confidence": min(best.confidence, VLM_FAILED_GREP_CONFIDENCE_CAP),
             "source": "agent_heuristic",
             "reason": f"VLM failed ({type(exc).__name__}); selected top grep candidate",
         }

--- a/apps/worker/app/services/document_agent/structure/page_locate_subagent.py
+++ b/apps/worker/app/services/document_agent/structure/page_locate_subagent.py
@@ -32,6 +32,8 @@ from app.services.document_agent.structure.hierarchy_locator import TitleMatch
 DecideFn = Callable[..., dict[str, Any] | None]
 
 _ALLOWED_ACTIONS = {"grep", "verify", "submit", "give_up"}
+VLM_MATCH_DEFAULT_CONFIDENCE = 0.7
+HEURISTIC_MATCH_DEFAULT_CONFIDENCE = 0.55
 
 
 @dataclass(frozen=True)
@@ -213,11 +215,15 @@ class PageLocateSubAgent:
         if vlm_confirmed:
             assert last_verify is not None  # guaranteed by vlm_confirmed check
             source = cast(Any, last_verify.get("source") or "agent_vlm")
-            confidence = float(last_verify.get("confidence") or 0.7)
+            confidence = float(last_verify.get("confidence") or VLM_MATCH_DEFAULT_CONFIDENCE)
             reason = last_verify.get("reason")
         else:
             source = cast(Any, "agent_heuristic")
-            confidence = float(decision.get("confidence") or grep_hit.get("confidence") or 0.55)
+            confidence = float(
+                decision.get("confidence")
+                or grep_hit.get("confidence")
+                or HEURISTIC_MATCH_DEFAULT_CONFIDENCE
+            )
             reason = decision.get("reason")
         return TitleMatch(
             page=page,
@@ -398,7 +404,6 @@ def _build_prompt(
         "   Searches body pages for the query (exact line, whitespace-insensitive "
         "compact text, and token overlap) and returns candidate pages with matched "
         "lines. IMPORTANT: the title may carry a trailing document-reference code "
-        "like （陕十一建[2022]30 号）, a 《》 wrapper, or a （试行）/（2020 版）note "
         "that never appears contiguously in the body, and the heading may be split "
         "across two lines. If a strict search of the full title returns nothing, "
         "retry grep with a shortened, distinctive CORE of the title (drop the "

--- a/apps/worker/app/services/document_agent/structure/page_locate_tools.py
+++ b/apps/worker/app/services/document_agent/structure/page_locate_tools.py
@@ -16,6 +16,8 @@ from app.services.document_agent.registry import register_tool
 from app.services.document_agent.structure import page_locate_agent as _pla
 from app.services.document_agent.structure.hierarchy_locator import TitleMatch
 
+SYNTHETIC_CANDIDATE_CONFIDENCE = 0.4
+
 
 @register_tool(
     name="grep.title_pages",
@@ -100,10 +102,10 @@ def verify_section_page(ctx: ToolContext, args: dict[str, Any]) -> ToolResult:
         grep_by_page.get(page)
         or TitleMatch(
             page=page,
-            confidence=0.4,
+            confidence=SYNTHETIC_CANDIDATE_CONFIDENCE,
             source="agent_heuristic",
             matched_line="",
-            score=0.4,
+            score=SYNTHETIC_CANDIDATE_CONFIDENCE,
             candidates=[page],
             evidence={"synthesized": True},
         )

--- a/apps/worker/app/services/document_parser/structure/heading_candidates.py
+++ b/apps/worker/app/services/document_parser/structure/heading_candidates.py
@@ -136,8 +136,8 @@ def remove_by_conditions(text, *, include_punc: bool = False):
     else:
         neg_triggered_code.append(0)
 
-    MAX_HEADING_TOKENS_ZH = 30
-    MAX_HEADING_TOKENS_EN = 10
+    MAX_HEADING_TOKENS_ZH = 60
+    MAX_HEADING_TOKENS_EN = 30
     _limit = MAX_HEADING_TOKENS_ZH if detect_primary_lang(text) == "zh" else MAX_HEADING_TOKENS_EN
     neg_triggered_code.append(1 if count_cn_en(text) > _limit else 0)
 

--- a/apps/worker/app/services/document_parser/structure/heading_llm_executor.py
+++ b/apps/worker/app/services/document_parser/structure/heading_llm_executor.py
@@ -122,17 +122,22 @@ def run_merge_pre_pass(
     compact_df: pd.DataFrame,
     model_name: str | None = None,
 ) -> dict[int, str]:
-    """Focused pre-pass: decide merge/keep for consecutive heading candidate groups.
+    """DEPRECATED — no longer wired into the pipeline. Kept for reference only.
 
-    Runs BEFORE the main hierarchy LLM call. Scans ``compact_df`` (output of
-    ``compact_for_llm``) for rows whose ``note == "?"``, groups them together
-    with their preceding candidate, and sends all groups in a single focused
-    ``eval-merge-groups`` LLM call.
+    This focused "are these two consecutive lines one split heading?" pre-pass
+    proved unreliable: the LLM frequently merged real chapter headings (e.g.
+    ``第一章 总则``) into the preceding document title, irreversibly destroying
+    structure. The merge concern is now handled declaratively by Rule 2 of the
+    ``eval-headings`` prompt ("no body between two candidates ⇒ not same level").
 
-    Returns a dict ``{row_id: "<"}`` for every row the LLM decides to merge
-    into the previous heading.  The caller seeds ``llm_levels`` with these
-    decisions before running the main hierarchy LLM so that merge decisions
-    are final and the main LLM only handles level assignment.
+    DO NOT call this. Retained so the approach can be revisited if needed.
+
+    ---
+    Focused pre-pass: decide merge/keep for consecutive heading candidate groups.
+    Scans ``compact_df`` (output of ``compact_for_llm``) for rows whose
+    ``note == "?"``, groups them with their preceding candidate, and sends all
+    groups in a single ``eval-merge-groups`` LLM call. Returns ``{row_id: "<"}``
+    for every row the LLM decides to merge into the previous heading.
     """
     # ── 1. Collect consecutive groups ──
     groups: list[list[dict[str, Any]]] = []  # each element: list of {id, heading}
@@ -233,6 +238,108 @@ def run_merge_pre_pass(
     return merge_ids
 
 
+def _coerce_level(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return -1
+
+
+def demote_consecutive_same_level(
+    compact_df: pd.DataFrame,
+    llm_levels: dict[int, Any],
+) -> set[int]:
+    """Demote runs of consecutive same-level candidates to body text (-1).
+
+    A real heading owns the body block that follows it. So a run of two or more
+    candidates that are (a) directly adjacent with NO ``[N BODY LINES]``
+    placeholder between them and (b) assigned the SAME level > 0 by the LLM is
+    NOT a set of sibling headings — it is a flat enumeration / list that leaked
+    in as candidates. Every member of such a run is forced to level -1.
+
+    Operates on the COMPACT chunk frame (placeholders mark body blocks) and
+    mutates ``llm_levels`` in place. Returns the set of demoted row ids.
+
+    Note: a candidate the LLM already demoted to -1 naturally breaks the run,
+    because -1 never equals a positive level — it acts like a body separator.
+    """
+    demoted: set[int] = set()
+    run: list[tuple[int, int]] = []  # (row_id, level) for a no-body candidate run
+
+    def flush(current_run: list[tuple[int, int]]) -> None:
+        idx = 0
+        n = len(current_run)
+        while idx < n:
+            end = idx + 1
+            while end < n and current_run[end][1] == current_run[idx][1]:
+                end += 1
+            if current_run[idx][1] > 0 and (end - idx) >= 2:
+                for k in range(idx, end):
+                    rid = current_run[k][0]
+                    llm_levels[rid] = -1
+                    demoted.add(rid)
+            idx = end
+
+    for _, row in compact_df.iterrows():
+        if str(row.get("reason")) == PLACEHOLDER_REASON:
+            flush(run)
+            run = []
+            continue
+        try:
+            rid = int(row["id"])
+        except (TypeError, ValueError):
+            # Non-integer id (defensive) — treat like a body separator
+            flush(run)
+            run = []
+            continue
+        run.append((rid, _coerce_level(llm_levels.get(rid, -1))))
+
+    flush(run)
+
+    if demoted:
+        logger.info(
+            f"post-process => demoted {len(demoted)} row(s) from "
+            f"consecutive same-level runs: {sorted(demoted)}"
+        )
+    return demoted
+
+
+def extract_active_ancestors(
+    compact_df: pd.DataFrame,
+    llm_levels: dict[int, Any],
+    initial_stack: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Return the stack of still-open ancestor headings at the END of a chunk.
+
+    Walks the chunk's (post-processed) candidates in order, maintaining a
+    heading stack with the usual ``pop while top.level >= level`` rule. The
+    leftover stack is the set of headings whose sections continue past the chunk
+    boundary — this is fed to the NEXT chunk as ``preceding_context`` so the LLM
+    continues the same level scale instead of restarting at level 1.
+
+    ``initial_stack`` seeds the walk with the previous chunk's open ancestors so
+    a chunk that contains no shallow heading still carries earlier context.
+    Returned chain is ordered shallow→deep as ``[{"heading", "level"}, ...]``.
+    """
+    stack: list[dict[str, Any]] = [dict(item) for item in (initial_stack or [])]
+
+    for _, row in compact_df.iterrows():
+        if str(row.get("reason")) == PLACEHOLDER_REASON:
+            continue
+        try:
+            rid = int(row["id"])
+        except (TypeError, ValueError):
+            continue
+        level = _coerce_level(llm_levels.get(rid, -1))
+        if level <= 0:
+            continue
+        while stack and stack[-1]["level"] >= level:
+            stack.pop()
+        stack.append({"heading": str(row["heading"]).strip(), "level": level})
+
+    return stack
+
+
 def execute_llm_heading_hierarchy(
     raw_preds: pd.DataFrame,
     prompt_limt: int,
@@ -273,14 +380,9 @@ def execute_llm_heading_hierarchy(
         fallback["level"] = -1
         return fallback.sort_values("id").reset_index(drop=True)
 
-    # ── Merge pre-pass (always on when compact is enabled) ──
-    # Runs a focused LLM call BEFORE the main hierarchy call to resolve all
-    # consecutive-candidate groups. Main LLM receives clean [id, heading] only.
-    pre_pass_levels: dict[int, str] = {}
-    if compact_enabled:
-        pre_pass_levels = run_merge_pre_pass(
-            preds_for_llm, model_name=model_name
-        )
+    # NOTE: the legacy LLM "merge pre-pass" (run_merge_pre_pass) is deprecated and
+    # no longer wired in. The merge concern is now handled by Rule 2 of the
+    # eval-headings prompt. The main hierarchy LLM assigns every level directly.
 
     level_dfs, _raw_headings = split_heading_table(
         preds_for_llm, threshold=prompt_limt, max_start=max_len, max_end=5
@@ -300,9 +402,13 @@ def execute_llm_heading_hierarchy(
             source_row_count=len(raw_preds),
             model_name=model_name,
         ):
-            # ── Per-chunk independent LLM calls ──
-            # Seed with pre-pass merge decisions; main LLM cannot override them
-            llm_levels: dict[int, Any] = dict(pre_pass_levels)
+            # ── Per-chunk LLM calls with cross-chunk hierarchy continuity ──
+            # Each chunk's post-processed open-ancestor chain is fed to the next
+            # chunk so the LLM continues the same level scale instead of
+            # restarting at level 1 (which previously caused mid-section jumps,
+            # e.g. 5.2.3 collapsing to a top-level node at a chunk boundary).
+            llm_levels: dict[int, Any] = {}
+            active_ancestor_chain: list[dict[str, Any]] = []
 
             for chunk_idx, chunk_df in enumerate(level_dfs):
                 # Skip chunks that contain only placeholders
@@ -319,10 +425,16 @@ def execute_llm_heading_hierarchy(
 
                 logger.info(
                     f"smart parse => chunk {chunk_idx}/{len(level_dfs)}: "
-                    f"sending {len(df4llm)} rows to LLM"
+                    f"sending {len(df4llm)} rows to LLM "
+                    f"(preceding ancestors: {len(active_ancestor_chain)})"
                 )
                 chunk_result = hierarchy_judge(
-                    df4llm, model_name, max_depth, toc_hierarchies, task="eval-headings"
+                    df4llm,
+                    model_name,
+                    max_depth,
+                    toc_hierarchies,
+                    task="eval-headings",
+                    preceding_context=active_ancestor_chain,
                 )
 
                 if isinstance(chunk_result, list):
@@ -330,14 +442,14 @@ def execute_llm_heading_hierarchy(
                         if isinstance(item, dict) and "id" in item and "level" in item:
                             try:
                                 row_id = int(item["id"])
-                                # Pre-pass merge decisions take priority — never override
-                                if row_id in pre_pass_levels:
-                                    continue
                                 llm_levels[row_id] = item["level"]
                             except (TypeError, ValueError):
                                 pass
 
-                # Save per-chunk intermediate CSV
+                # Save per-chunk raw LLM prediction BEFORE deterministic
+                # post-processing. ``preds_llm_*`` is intentionally the model's
+                # direct judgment; ``preds_final`` is saved later after all
+                # post-processing and tree cleanup.
                 chunk_preds = (
                     chunk_df[["id", "heading", "reason"]].copy().reset_index(drop=True)
                 )
@@ -354,6 +466,14 @@ def execute_llm_heading_hierarchy(
                     f"preds_llm{csv_suffix}_{chunk_idx}"
                 )
 
+                # ── Post-process this chunk BEFORE it informs the next chunk ──
+                # Demote runs of consecutive same-level candidates (flat lists)
+                # to body text, then derive the open-ancestor chain to carry.
+                demote_consecutive_same_level(chunk_df, llm_levels)
+                active_ancestor_chain = extract_active_ancestors(
+                    chunk_df, llm_levels, initial_stack=active_ancestor_chain
+                )
+
             logger.info(
                 f"smart parse => per-chunk LLM produced {len(llm_levels)} "
                 f"id->level entries across {len(level_dfs)} chunks"
@@ -367,9 +487,6 @@ def execute_llm_heading_hierarchy(
                 except (TypeError, ValueError):
                     return -1
                 level = llm_levels.get(int_id, -1)
-                # Pre-pass merge decisions arrive as "<"; pass through for _apply_merge_signals
-                if level == "<":
-                    return "<"
                 try:
                     return int(level)
                 except (TypeError, ValueError):

--- a/apps/worker/app/services/document_parser/structure/layout_parser.py
+++ b/apps/worker/app/services/document_parser/structure/layout_parser.py
@@ -137,6 +137,28 @@ def format_toc_context_for_llm(toc_context) -> str:
     return "\n".join(formatted_blocks)
 
 
+def _format_preceding_context_for_llm(chain) -> str:
+    """Render the carried open-ancestor chain (shallow→deep) for the prompt.
+
+    ``chain`` is a list of ``{"heading": str, "level": int}`` produced by
+    ``extract_active_ancestors`` for the PREVIOUS chunk of the same document.
+    Returns "" when there is no preceding context (i.e. the first chunk).
+    """
+    if not chain:
+        return ""
+    lines = []
+    for item in chain:
+        try:
+            level = int(item.get("level"))
+        except (TypeError, ValueError):
+            continue
+        heading = str(item.get("heading", "")).strip()
+        if not heading:
+            continue
+        lines.append(f"  level {level}: {heading}")
+    return "\n".join(lines)
+
+
 def hiearchy_llm(
     df,
     model_name=None,
@@ -144,6 +166,7 @@ def hiearchy_llm(
     toc_context=None,
     max_len=8192,
     task="eval-headings",
+    preceding_context=None,
 ):
     """Apply LLM to analyze the hierarchy of headings
 
@@ -182,11 +205,13 @@ def hiearchy_llm(
     ot_limit = max(512, n_candidates * 25 + 200)
     ot_limit = min(ot_limit, max_len)
     formatted_toc_context = format_toc_context_for_llm(toc_context)
+    formatted_preceding_context = _format_preceding_context_for_llm(preceding_context)
 
     paras = {
         "max_tokens": ot_limit,
         "max_depth": max_depth,
         "toc_context": formatted_toc_context,
+        "preceding_context": formatted_preceding_context,
     }
     prompt, temperature, top_p, max_tokens = build_prompt(
         task=task, texts=level_md, query="", paras=paras

--- a/apps/worker/app/services/page_memory/skeleton_extractor.py
+++ b/apps/worker/app/services/page_memory/skeleton_extractor.py
@@ -49,6 +49,7 @@ def extract_section_skeletons(
     filename: str,
     page_texts: dict[int, str],
     ctx: ToolContext | None = None,
+    hierarchy_nodes: list[TitleNode] | None = None,
 ) -> list[SectionSkeleton]:
     """Convert PageAnatomyMap hierarchy evidence into leaf section skeletons."""
     page_count = _page_count(anatomy)
@@ -56,12 +57,16 @@ def extract_section_skeletons(
     if page_count <= 0:
         return [_root_skeleton(root_path=root_path, filename=filename, page_count=0)]
 
-    toc_hierarchies, toc_selection = _select_global_toc_hierarchies(
-        anatomy=anatomy,
-        filename=filename,
-    )
-    toc_nodes = extract_toc_nodes(toc_hierarchies)
-    nodes = toc_nodes or _h1_nodes(anatomy)
+    toc_selection: dict[str, Any] = {}
+    if hierarchy_nodes:
+        nodes = hierarchy_nodes
+    else:
+        toc_hierarchies, toc_selection = _select_global_toc_hierarchies(
+            anatomy=anatomy,
+            filename=filename,
+        )
+        toc_nodes = extract_toc_nodes(toc_hierarchies)
+        nodes = toc_nodes or _h1_nodes(anatomy)
     if not nodes:
         return [
             _root_skeleton(

--- a/packages/shared-python/shared/services/ai/openai_compatible_client_sync.py
+++ b/packages/shared-python/shared/services/ai/openai_compatible_client_sync.py
@@ -309,11 +309,15 @@ class OpenAICompatibleClientSync:
                 api_kwargs[key] = value
 
         if "extra_body" not in api_kwargs:
-            api_kwargs["extra_body"] = {"enable_thinking": False}
+            api_kwargs["extra_body"] = {
+                "enable_thinking": False,
+                "thinking": {"type": "disabled"},
+            }
         else:
             extra_body = api_kwargs["extra_body"]
             if isinstance(extra_body, dict):
                 extra_body.setdefault("enable_thinking", False)
+                extra_body.setdefault("thinking", {"type": "disabled"})
 
         effective_model = model or self.default_model
         if _should_mock_llm_calls():
@@ -407,11 +411,15 @@ class OpenAICompatibleClientSync:
         # Only inject the disable flag when the caller hasn't already set extra_body
         # (e.g. DeepSeek thinking mode explicitly passes its own extra_body).
         if "extra_body" not in api_kwargs:
-            api_kwargs["extra_body"] = {"enable_thinking": False}
+            api_kwargs["extra_body"] = {
+                "enable_thinking": False,
+                "thinking": {"type": "disabled"},
+            }
         else:
             extra_body = api_kwargs["extra_body"]
             if isinstance(extra_body, dict):
                 extra_body.setdefault("enable_thinking", False)
+                extra_body.setdefault("thinking", {"type": "disabled"})
 
         effective_model = model or self.default_model
         if _should_mock_llm_calls():

--- a/packages/shared-python/shared/services/ai/prompt_service.py
+++ b/packages/shared-python/shared/services/ai/prompt_service.py
@@ -349,6 +349,7 @@ def build_prompt(task, texts, query, **kwargs):
         max_depth = kwargs["paras"]["max_depth"]
         max_tokens = kwargs["paras"]["max_tokens"]
         toc_context = kwargs["paras"].get("toc_context", "")
+        preceding_context = kwargs["paras"].get("preceding_context", "")
 
         if toc_context:
             toc_section = f"""
@@ -358,7 +359,7 @@ def build_prompt(task, texts, query, **kwargs):
         {toc_context}
         '''
 
-        RULES for using the TOC:
+        RULES for using the TOC (the SKELETON of the document):
         1. MUST TRUST the TOC levels as ground truth. If a candidate heading matches or
            closely corresponds to a TOC entry, you MUST assign it the same level as
            the TOC entry. Do NOT override or re-interpret the TOC's level assignment.
@@ -368,12 +369,44 @@ def build_prompt(task, texts, query, **kwargs):
         3. A candidate that does NOT correspond to any TOC entry can only be:
            - Body text (level = -1), OR
            - A sub-section with a level deeper than its nearest TOC heading above it.
-        4. The TOC provides the SKELETON of the document. Your job is to fill in the
-           gaps for candidates not covered by the TOC, while strictly preserving the
-           TOC's structure.
         """
         else:
             toc_section = ""
+
+        if preceding_context:
+            preceding_section = f"""
+        ***PRECEDING CONTEXT (already-decided ancestor headings before this slice)***
+
+        This slice is a CONTINUATION of the SAME document. The headings below were
+        assigned in the PREVIOUS slice and their sections are still "open" — they
+        flow into this slice. They are listed shallow→deep with their FINAL levels:
+
+        '''
+        {preceding_context}
+        '''
+
+        RULES for using the PRECEDING CONTEXT:
+        1. Do NOT restart numbering at level 1. Continue the SAME level scale shown above.
+        2. The FIRST heading you assign must be either a SIBLING of one of the open
+           ancestors (same level as that ancestor) or a CHILD of the DEEPEST open
+           ancestor (exactly one level deeper). It must NEVER be shallower than the
+           shallowest ancestor shown unless it clearly opens a new coarse section.
+        3. Apply the same parent-child continuity / no-skipping rules across the
+           boundary as if the preceding headings physically preceded this slice.
+        """
+        else:
+            preceding_section = ""
+
+        if preceding_context:
+            rule_5 = """Rule 5 — Continue the level scale from PRECEDING CONTEXT (do NOT reset to 1):
+            This slice continues an earlier slice of the same document, so the
+            shallowest heading here is NOT necessarily level 1. Align the first
+            heading with the open ancestor levels in PRECEDING CONTEXT (sibling =
+            same level, sub-section = one level deeper) and keep every level on
+            that same scale."""
+        else:
+            rule_5 = """Rule 5 — Normalise to start at level 1:
+            The shallowest (the most coarse granularity) heading found MUST be assigned level 1."""
 
         prompt = f"""
         You are a document structure auditing expert. The input you receive is a
@@ -395,11 +428,13 @@ def build_prompt(task, texts, query, **kwargs):
         '''
 
         {toc_section}
+        
+        {preceding_section}
 
         ***Hard rules about placeholders***
         - Placeholders are NEVER candidates. Do not output them.
         - Every ``id`` in your output MUST be a single integer; never emit an id containing a hyphen.
-        - Use N in ``[N BODY LINES]`` as a "section bulk" signal when applying rules below (Rule 2 in particular).
+        - Use N in ``[N BODY LINES]`` as a "section bulk" signal when applying rules below (Rules 2 and 3 in particular).
 
         ***Process in TWO steps:***
 
@@ -418,11 +453,6 @@ def build_prompt(task, texts, query, **kwargs):
         Your task is to determine each candidate's heading level from scratch
         based on its text, context, and the patterns discovered in STEP 1.
 
-        Rule 0 — Global consistency:
-            Candidates sharing the same structural pattern or semantic granularity SHOULD receive the
-            SAME level across the ENTIRE input. (e.g. every "X.Y" pattern
-            shares one level; every "X.Y.Z" shares a different, deeper level.)
-
         Rule 1 — Parent-child continuity and no level skipping:
             A heading, compared to candidates before it, may stay at the same level,
             or go ONE level deeper than its nearest valid ancestor heading.
@@ -435,7 +465,6 @@ def build_prompt(task, texts, query, **kwargs):
             b) In the input sequence it is IMMEDIATELY followed by a
                 placeholder ``[N BODY LINES]``, or by another candidate with finer granularity.
                 This is the "section bulk" signal — the row introduces a body block or a subsection group.
-            When Rule-2 is satisfied, pick a level consistent with Rule 1.
 
         Rule 3 — Body text demotion (candidate → -1):
             Demote a candidate to level = -1 when it clearly does NOT serve as a
@@ -443,8 +472,7 @@ def build_prompt(task, texts, query, **kwargs):
             - The text is an isolated fragment, data value, or caption-like snippet (e.g. "Table x", "Figure x", "Table/Figure").
             - The text has sentence-ending punctuation or is clearly prose.
 
-        Rule 4 — Normalise to start at level 1:
-            The shallowest (the most coarse granularity) heading found MUST be assigned level 1.
+        {rule_5}
 
         ***Output requirements***
         - Output MUST be a [JSON array] only.

--- a/packages/shared-python/shared/services/retrieval/hydration/result_assembly.py
+++ b/packages/shared-python/shared/services/retrieval/hydration/result_assembly.py
@@ -69,6 +69,15 @@ async def assemble_retrieval_results(
                     connected_targets.append((sort_key, target_content))
             connected_targets.sort(key=lambda item: item[0])
             related_parts = [content for _, content in connected_targets]
+
+            # TODO: Oversized Table Protection for results[].content
+            # Currently, if a text chunk connects to a large table (e.g., 50K chars), 
+            # the full table HTML is appended here without any truncation.
+            # We should consider whether to truncate this and only leave the asset URL.
+            #
+            # TODO: Dedicated Large Table Agent
+            # For the Notebook/Agent environment, consider introducing a dedicated 
+            # "Large Table Agent" that can fetch and query oversized tables via URL.
             if base_content and related_parts:
                 assembled_row['content'] = '\n\n'.join([base_content, *related_parts])
             else:


### PR DESCRIPTION
## Summary

Enhance heading hierarchy evaluation with cross-chunk level continuity and improved default thinking mode control.

## Changes

### Page-Based Pipeline (isolated, not wired into main flow)
- `page_locate_agent/subagent/tools`: Page-based parsing refinements
- `skeleton_extractor`: Page memory skeleton improvements

### Heading Evaluation (backward-compatible improvements)
- `heading_llm_executor`: Deprecate unreliable `run_merge_pre_pass` (was merging real chapter headings into preceding titles). Add `demote_consecutive_same_level` post-processing and `extract_active_ancestors` for cross-chunk hierarchy continuity
- `heading_candidates`: Relax token limits (30→60 zh, 10→30 en) to allow longer candidate headings
- `layout_parser`: Add optional `preceding_context` param to `hiearchy_llm()` (default None = no effect on existing callers)
- `prompt_service`: Add PRECEDING CONTEXT section + dynamic Rule 5 for `eval-headings` prompt. Uses `.get()` with empty default — zero impact when not provided

### Shared Infrastructure (safe defaults)
- `openai_compatible_client_sync`: Explicitly disable thinking mode via both `enable_thinking=False` and `thinking.type=disabled` (defense-in-depth for deepseek-v4-flash)
- `result_assembly`: Add TODO comments for oversized table handling

## Impact on Main Flow
- All new parameters use `None`/empty defaults — **existing callers are unaffected**
- `run_merge_pre_pass` is deprecated but retained for reference — its removal is a bugfix
- Token limit relaxation is intentional to catch valid longer headings

## Testing
- `make check` (ruff + pyright): **0 errors, 0 warnings**