### PR TITLE
feat: enforce dashboard token permissions

### DIFF
--- a/apps/api/app/api/dependencies/auth.py
+++ b/apps/api/app/api/dependencies/auth.py
@@ -3,13 +3,19 @@
 from app.services.auth.current_user_authentication_service import (
     get_current_user_authentication_service,
 )
-from fastapi import Depends, Header
+from app.services.auth.dashboard_jwt_authentication_service import (
+    FULL_ACCESS_PERMISSION,
+    READ_ONLY_PERMISSION,
+)
+from fastapi import Depends, Header, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from shared.core.database import get_db
+from shared.core.exceptions.domain_exceptions import PermissionDeniedException
 
 
 async def get_current_user_id(
+    request: Request,
     authorization: str | None = Header(
         default=None,
         description="Bearer <token> OR internal signature auth",
@@ -17,7 +23,26 @@ async def get_current_user_id(
     db: AsyncSession = Depends(get_db),
 ) -> str:
     """Authenticate the caller and return the current user ID."""
-    return await get_current_user_authentication_service().authenticate_authorization_header(
+    identity = await get_current_user_authentication_service().authenticate_authorization_header_with_identity(
         db,
         authorization,
+    )
+    request.state.user_id = identity.user_id
+    request.state.permission = identity.permission
+    request.state.auth_source = identity.source
+    return identity.user_id
+
+
+async def require_write_permission(
+    request: Request,
+    _user_id: str = Depends(get_current_user_id),
+) -> None:
+    """Reject write operations for read-only Dashboard tokens."""
+    permission = getattr(request.state, "permission", FULL_ACCESS_PERMISSION)
+    if permission != READ_ONLY_PERMISSION:
+        return
+
+    raise PermissionDeniedException(
+        user_message="This token is read only.",
+        required_permission=FULL_ACCESS_PERMISSION,
     )

--- a/apps/api/app/api/v1/routes/api_key.py
+++ b/apps/api/app/api/v1/routes/api_key.py
@@ -2,8 +2,9 @@
 API key management endpoints.
 """
 
-from app.services.auth.api_key_management_service import APIKeyManagementService
+from app.api.dependencies.auth import require_write_permission
 from app.api.dependencies.current_user import with_current_user
+from app.services.auth.api_key_management_service import APIKeyManagementService
 from app.services.rate_limit.data_structures import CurrentUser
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,6 +31,7 @@ _api_key_management_service = APIKeyManagementService()
 async def create_api_key(
     request: CreateAPIKeyRequest,
     current_user: CurrentUser = Depends(with_current_user),
+    _write_permission: None = Depends(require_write_permission),
     db: AsyncSession = Depends(get_db),
 ):
     """Create an API key."""
@@ -97,6 +99,7 @@ async def list_api_keys(
 async def revoke_api_key(
     request: RevokeAPIKeyRequest,
     current_user: CurrentUser = Depends(with_current_user),
+    _write_permission: None = Depends(require_write_permission),
     db: AsyncSession = Depends(get_db),
 ):
     """Revoke an API key."""
@@ -160,6 +163,7 @@ async def get_api_key(
 async def toggle_api_key(
     api_key_id: str,
     current_user: CurrentUser = Depends(with_current_user),
+    _write_permission: None = Depends(require_write_permission),
     db: AsyncSession = Depends(get_db),
 ):
     """Enable or disable an API key."""

--- a/apps/api/app/api/v1/routes/billing.py
+++ b/apps/api/app/api/v1/routes/billing.py
@@ -2,11 +2,12 @@
 
 from typing import Optional
 
+from app.api.dependencies.auth import require_write_permission
+from app.api.dependencies.current_user import with_current_user
 from app.services.billing.billing_workflow_service import (
     BillingWorkflowService,
     ParseUsageResponse,
 )
-from app.api.dependencies.current_user import with_current_user
 from app.services.rate_limit.data_structures import CurrentUser
 from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,10 +26,13 @@ router = APIRouter(tags=["Billing"])
 _billing_workflow_service = BillingWorkflowService()
 
 
-@router.post("/buy-credits", summary="Buy Credits", response_model=PaymentIntentResponse)
+@router.post(
+    "/buy-credits", summary="Buy Credits", response_model=PaymentIntentResponse
+)
 async def buy_credits(
     request: BuyCreditsRequest,
     current_user: CurrentUser = Depends(with_current_user),
+    _write_permission: None = Depends(require_write_permission),
     db: AsyncSession = Depends(get_db),
 ) -> PaymentIntentResponse:
     return await _billing_workflow_service.buy_credits(
@@ -119,6 +123,7 @@ async def get_price_configs(
 async def buy_credits_package(
     request: BuyCreditsPackageRequest,
     current_user: CurrentUser = Depends(with_current_user),
+    _write_permission: None = Depends(require_write_permission),
     db: AsyncSession = Depends(get_db),
 ) -> CheckoutSessionResponse:
     return await _billing_workflow_service.buy_credits_package(

--- a/apps/api/app/api/v1/routes/demo.py
+++ b/apps/api/app/api/v1/routes/demo.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from app.services.demo.document_service import DemoDocumentService
+from app.api.dependencies.auth import require_write_permission
 from app.api.dependencies.current_user import with_current_user
+from app.services.demo.document_service import DemoDocumentService
 from app.services.rate_limit.data_structures import CurrentUser
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import FileResponse
@@ -124,6 +125,7 @@ async def get_demo_source_asset(
 async def materialize_demo_sources(
     payload: DemoMaterializeRequest,
     current_user: CurrentUser = Depends(with_current_user),
+    _write_permission: None = Depends(require_write_permission),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Copy canonical demo sources into the authenticated user's namespace."""

--- a/apps/api/app/api/v1/routes/documents.py
+++ b/apps/api/app/api/v1/routes/documents.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Literal
 
+from app.api.dependencies.auth import require_write_permission
 from app.api.dependencies.current_user import with_current_user
 from app.services.documents.lifecycle_service import DocumentService
 from app.services.rate_limit.data_structures import CurrentUser
@@ -130,6 +131,7 @@ async def get_document_chunk(
 async def archive_document(
     document_id: str,
     current_user: CurrentUser = Depends(with_current_user),
+    _write_permission: None = Depends(require_write_permission),
     db: AsyncSession = Depends(get_db),
 ):
     return await _archive_document_response(
@@ -143,6 +145,7 @@ async def archive_document(
 async def archive_document_legacy(
     document_id: str,
     current_user: CurrentUser = Depends(with_current_user),
+    _write_permission: None = Depends(require_write_permission),
     db: AsyncSession = Depends(get_db),
 ):
     return await _archive_document_response(

--- a/apps/api/app/api/v1/routes/jobs.py
+++ b/apps/api/app/api/v1/routes/jobs.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
+from app.api.dependencies.auth import require_write_permission
+from app.api.dependencies.current_user import with_current_user
+from app.api.dependencies.job_admission import require_billing_limits
 from app.services.document_ingestion import DocumentIngestionService
 from app.services.jobs import (
     get_job_result_for_user,
     list_jobs_for_user,
 )
-from app.api.dependencies.current_user import with_current_user
-from app.api.dependencies.job_admission import require_billing_limits
 from app.services.rate_limit.data_structures import CurrentUser
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -39,6 +40,7 @@ _document_ingestion_service = DocumentIngestionService()
 async def create_job(  # pyright: ignore[reportGeneralTypeIssues]
     payload: JobCreate,
     current_user: CurrentUser = Depends(require_billing_limits),
+    _write_permission: None = Depends(require_write_permission),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -111,6 +113,7 @@ async def confirm_upload(
     job_id: str,
     request: Optional[ConfirmUploadRequest] = None,
     current_user: CurrentUser = Depends(with_current_user),
+    _write_permission: None = Depends(require_write_permission),
     db: AsyncSession = Depends(get_db),
 ):
     """

--- a/apps/api/app/api/v1/routes/webhook.py
+++ b/apps/api/app/api/v1/routes/webhook.py
@@ -7,9 +7,10 @@ Webhook API Routes
 
 from typing import Optional
 
+from app.api.dependencies.auth import require_write_permission
+from app.api.dependencies.current_user import with_current_user
 from app.repositories.job_repository import JobRepository
 from app.repositories.webhook_repository import WebhookRepository
-from app.api.dependencies.current_user import with_current_user
 from app.services.rate_limit.data_structures import CurrentUser
 from fastapi import APIRouter, Depends, Query
 from loguru import logger
@@ -95,6 +96,7 @@ async def get_webhook_logs(
 async def trigger_webhook(
     request: WebhookTriggerRequest,
     current_user: CurrentUser = Depends(with_current_user),
+    _write_permission: None = Depends(require_write_permission),
     db: AsyncSession = Depends(get_db),
 ):
     """

--- a/apps/api/app/api/v1/routes/webhook_secrets.py
+++ b/apps/api/app/api/v1/routes/webhook_secrets.py
@@ -6,6 +6,7 @@ Endpoints for managing user webhook signing secrets.
 
 from typing import List, Optional
 
+from app.api.dependencies.auth import require_write_permission
 from app.api.dependencies.current_user import with_current_user
 from app.services.rate_limit.data_structures import CurrentUser
 from fastapi import APIRouter, Depends
@@ -131,6 +132,7 @@ async def list_secrets(
 async def create_secret(
     request: SecretCreateRequest,
     current_user: CurrentUser = Depends(with_current_user),
+    _write_permission: None = Depends(require_write_permission),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -159,6 +161,7 @@ async def create_secret(
 async def revoke_secret(
     secret_id: str,
     current_user: CurrentUser = Depends(with_current_user),
+    _write_permission: None = Depends(require_write_permission),
     db: AsyncSession = Depends(get_db),
 ):
     """

--- a/apps/api/app/services/auth/current_user_authentication_service.py
+++ b/apps/api/app/services/auth/current_user_authentication_service.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Literal
+
 from app.services.auth.api_key_authentication_service import (
     APIKeyAuthenticationService,
 )
 from app.services.auth.dashboard_jwt_authentication_service import (
     DashboardJWTAuthenticationService,
+    FULL_ACCESS_PERMISSION,
+    Permission,
     get_dashboard_jwt_authentication_service,
 )
 from sqlalchemy import select
@@ -15,6 +20,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from shared.core.exceptions.domain_exceptions import AuthException
 from shared.models.database.user import User
 from shared.utils.api_keys import is_api_key_token
+
+AuthSource = Literal["api_key", "jwt"]
+
+
+@dataclass(frozen=True)
+class AuthenticatedIdentity:
+    user_id: str
+    permission: Permission
+    source: AuthSource
 
 
 class CurrentUserAuthenticationService:
@@ -42,6 +56,18 @@ class CurrentUserAuthenticationService:
         authorization: str | None,
     ) -> str:
         """Authenticate an Authorization header and return the owning user ID."""
+        identity = await self.authenticate_authorization_header_with_identity(
+            session,
+            authorization,
+        )
+        return identity.user_id
+
+    async def authenticate_authorization_header_with_identity(
+        self,
+        session: AsyncSession,
+        authorization: str | None,
+    ) -> AuthenticatedIdentity:
+        """Authenticate an Authorization header and return identity details."""
         token = self._extract_bearer_token(authorization)
 
         if is_api_key_token(token):
@@ -50,12 +76,20 @@ class CurrentUserAuthenticationService:
                 token,
             )
             if user_id:
-                return user_id
+                return AuthenticatedIdentity(
+                    user_id=user_id,
+                    permission=FULL_ACCESS_PERMISSION,
+                    source="api_key",
+                )
             raise AuthException(user_message="Invalid API Key")
 
-        user_id = self._dashboard_jwt_authentication_service.decode_user_id(token)
-        await self._ensure_authenticated_user_exists(session, user_id)
-        return user_id
+        identity = self._dashboard_jwt_authentication_service.decode_identity(token)
+        await self._ensure_authenticated_user_exists(session, identity.user_id)
+        return AuthenticatedIdentity(
+            user_id=identity.user_id,
+            permission=identity.permission,
+            source="jwt",
+        )
 
     @staticmethod
     def _extract_bearer_token(authorization: str | None) -> str:
@@ -75,7 +109,9 @@ class CurrentUserAuthenticationService:
         session: AsyncSession,
         user_id: str,
     ) -> None:
-        result = await session.execute(select(User.id).where(User.id == user_id).limit(1))
+        result = await session.execute(
+            select(User.id).where(User.id == user_id).limit(1)
+        )
         if result.scalar_one_or_none() is not None:
             return
 

--- a/apps/api/app/services/auth/dashboard_jwt_authentication_service.py
+++ b/apps/api/app/services/auth/dashboard_jwt_authentication_service.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import threading
+from dataclasses import dataclass
 from datetime import timedelta
-from typing import Any
+from typing import Any, Literal
 
 import jwt
 from jwt import PyJWKClient
@@ -15,6 +16,15 @@ from shared.core.exceptions.domain_exceptions import AuthException
 
 JWKS_ENDPOINT_PATH = "/api/auth/jwks"
 JWKS_CACHE_TTL_SECONDS = 60 * 60
+READ_ONLY_PERMISSION: Literal["read_only"] = "read_only"
+FULL_ACCESS_PERMISSION: Literal["full_access"] = "full_access"
+Permission = Literal["read_only", "full_access"]
+
+
+@dataclass(frozen=True)
+class DashboardJWTIdentity:
+    user_id: str
+    permission: Permission
 
 
 class DashboardJWTAuthenticationService:
@@ -26,24 +36,34 @@ class DashboardJWTAuthenticationService:
 
     def decode_user_id(self, token: str) -> str:
         """Decode and validate a JWT, returning its authenticated user ID."""
+        return self.decode_identity(token).user_id
+
+    def decode_identity(self, token: str) -> DashboardJWTIdentity:
+        """Decode and validate a JWT, returning the user ID and permission."""
         try:
-            key = self._get_verification_key(token)
-            payload: dict[str, Any] = jwt.decode(
-                token,
-                key,
-                algorithms=["HS256", "RS256", "EdDSA"],
-                leeway=timedelta(seconds=30),
-                options={"verify_aud": False},
-            )
+            payload = self._decode_payload(token)
             user_id = payload.get("id")
             if not isinstance(user_id, str) or not user_id:
                 raise AuthException(user_message="Token missing 'id' claim")
-            return user_id
+
+            permission = _normalize_permission(payload.get("permission"))
+            return DashboardJWTIdentity(user_id=user_id, permission=permission)
         except jwt.ExpiredSignatureError:
             raise AuthException(user_message="Token has expired")
         except jwt.InvalidTokenError as exc:
             logger.warning(f"Invalid JWT token: {exc}")
             raise AuthException(user_message="Invalid token")
+
+    def _decode_payload(self, token: str) -> dict[str, Any]:
+        key = self._get_verification_key(token)
+        payload: dict[str, Any] = jwt.decode(
+            token,
+            key,
+            algorithms=["HS256", "RS256", "EdDSA"],
+            leeway=timedelta(seconds=30),
+            options={"verify_aud": False},
+        )
+        return payload
 
     def _get_verification_key(self, token: str) -> Any:
         """Resolve the JWT verification key from the Dashboard JWKS endpoint."""
@@ -55,8 +75,7 @@ class DashboardJWTAuthenticationService:
             logger.error(f"Failed to fetch JWKS: {exc}")
             raise AuthException(
                 internal_message=(
-                    "Failed to fetch verification key from JWKS endpoint: "
-                    f"{exc}"
+                    f"Failed to fetch verification key from JWKS endpoint: {exc}"
                 )
             )
         except jwt.PyJWKSetError as exc:
@@ -69,8 +88,7 @@ class DashboardJWTAuthenticationService:
             with self._jwks_client_lock:
                 if self._jwks_client is None:
                     jwks_url = (
-                        f"{settings.INTERNAL_DASHBOARD_ENDPOINT}"
-                        f"{JWKS_ENDPOINT_PATH}"
+                        f"{settings.INTERNAL_DASHBOARD_ENDPOINT}{JWKS_ENDPOINT_PATH}"
                     )
                     self._jwks_client = PyJWKClient(
                         jwks_url,
@@ -81,6 +99,13 @@ class DashboardJWTAuthenticationService:
                     logger.info(f"Initialized JWKS client with endpoint: {jwks_url}")
 
         return self._jwks_client
+
+
+def _normalize_permission(value: object) -> Permission:
+    if value == READ_ONLY_PERMISSION:
+        return READ_ONLY_PERMISSION
+
+    return FULL_ACCESS_PERMISSION
 
 
 _dashboard_jwt_authentication_service = DashboardJWTAuthenticationService()

--- a/apps/api/tests/contract/test_dashboard_token_permission_contract.py
+++ b/apps/api/tests/contract/test_dashboard_token_permission_contract.py
@@ -1,0 +1,161 @@
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+from datetime import datetime, timedelta, timezone
+from typing import Literal, cast
+from uuid import uuid4
+
+import jwt
+import pytest
+from httpx import AsyncClient
+from pytest import MonkeyPatch
+
+from shared.testing.contract_runtime import seed_contract_developer
+from tests.support.contract_database import ContractDatabase
+
+Permission = Literal["read_only", "full_access"]
+
+
+def _use_dashboard_token(
+    api_client: AsyncClient,
+    monkeypatch: MonkeyPatch,
+    *,
+    user_id: str,
+    permission: Permission | None,
+) -> None:
+    jwt_secret = f"contract-jwt-secret-{uuid4().hex[:12]}"
+    payload: dict[str, object] = {
+        "id": user_id,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+    }
+    if permission is not None:
+        payload["permission"] = permission
+
+    token = jwt.encode(payload, jwt_secret, algorithm="HS256")
+
+    from app.services.auth.dashboard_jwt_authentication_service import (
+        get_dashboard_jwt_authentication_service,
+    )
+
+    monkeypatch.setattr(
+        get_dashboard_jwt_authentication_service(),
+        "_get_verification_key",
+        lambda _token: jwt_secret,
+    )
+    api_client.headers.update({"Authorization": f"Bearer {token}"})
+
+
+async def _seed_dashboard_user() -> str:
+    developer_profile = await seed_contract_developer()
+    return cast(str, developer_profile["user_id"])
+
+
+async def _fetch_document_status(document_id: str) -> str:
+    row = await ContractDatabase.fetch_one(
+        """
+        SELECT status
+        FROM documents
+        WHERE document_id = :document_id
+        """,
+        {"document_id": document_id},
+    )
+    if row is None:
+        raise AssertionError(f"document not found: {document_id}")
+    return cast(str, row["status"])
+
+
+async def _count_user_jobs(user_id: str) -> int:
+    row = await ContractDatabase.fetch_one(
+        """
+        SELECT COUNT(*) AS total
+        FROM jobs
+        WHERE user_id = :user_id
+        """,
+        {"user_id": user_id},
+    )
+    if row is None:
+        return 0
+    return cast(int, row["total"])
+
+
+def _assert_read_only_error(response_json: dict[str, object]) -> None:
+    error = cast(dict[str, object], response_json["error"])
+    assert response_json["success"] is False
+    assert error["code"] == "PERMISSION_DENIED"
+    assert error["message"] == "This token is read only."
+    assert error["details"] == {"required_permission": "full_access"}
+
+
+@pytest.mark.asyncio
+async def test_read_only_dashboard_token_can_read_but_cannot_parse_or_archive(
+    api_client_factory: Callable[[], AbstractAsyncContextManager[AsyncClient]],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    document_id = f"doc_permission_{uuid4().hex[:12]}"
+    payload: dict[str, str] = {
+        "namespace": "contract-permission",
+        "source_type": "file",
+        "file_name": "contract-read-only.pdf",
+        "data_id": f"contract-read-only-{uuid4().hex[:12]}",
+    }
+
+    async with api_client_factory() as api_client:
+        user_id = await _seed_dashboard_user()
+        await ContractDatabase.insert_document(
+            document_id=document_id,
+            user_id=user_id,
+            namespace="contract-permission",
+        )
+        _use_dashboard_token(
+            api_client,
+            monkeypatch,
+            user_id=user_id,
+            permission="read_only",
+        )
+
+        list_jobs_response = await api_client.get("/api/v1/jobs")
+        get_document_response = await api_client.get(f"/api/v1/documents/{document_id}")
+        create_job_response = await api_client.post("/api/v1/jobs", json=payload)
+        archive_document_response = await api_client.post(
+            f"/api/v1/documents/{document_id}/archive"
+        )
+
+    assert list_jobs_response.status_code == 200
+    assert get_document_response.status_code == 200
+
+    assert create_job_response.status_code == 403
+    _assert_read_only_error(cast(dict[str, object], create_job_response.json()))
+
+    assert archive_document_response.status_code == 403
+    _assert_read_only_error(cast(dict[str, object], archive_document_response.json()))
+
+    assert await _count_user_jobs(user_id) == 0
+    assert await _fetch_document_status(document_id) == "active"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_token_without_permission_claim_keeps_full_access(
+    api_client_factory: Callable[[], AbstractAsyncContextManager[AsyncClient]],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    payload: dict[str, str] = {
+        "namespace": "contract-permission",
+        "source_type": "file",
+        "file_name": "contract-full-access.pdf",
+        "data_id": f"contract-full-access-{uuid4().hex[:12]}",
+    }
+
+    async with api_client_factory() as api_client:
+        user_id = await _seed_dashboard_user()
+        _use_dashboard_token(
+            api_client,
+            monkeypatch,
+            user_id=user_id,
+            permission=None,
+        )
+
+        response = await api_client.post("/api/v1/jobs", json=payload)
+
+    assert response.status_code == 200
+    response_json = cast(dict[str, object], response.json())
+    assert cast(str, response_json["job_id"]).startswith("job_")
+    assert response_json["status"] == "waiting-file"


### PR DESCRIPTION
## Summary
- decode Dashboard-issued JWT permission claims in the Knowhere API
- block read-only dashboard tokens from parse, archive/delete, API key, billing, webhook, and demo materialization writes
- keep API-key and legacy dashboard JWT behavior full access for backwards compatibility

## Verification
- Shared local DB flow: dashboard + API + worker on Knowhere_mcp_permission_flow_20260625; full_access token parsed job_427b547bb61b into doc_e897d41e41ad; read_only token read the document/chunks and received 403 on parse/archive
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest apps/api/tests/contract/test_dashboard_token_permission_contract.py
- UV_CACHE_DIR=/tmp/uv-cache uv run pyright apps/api/app apps/api/tests/contract/test_dashboard_token_permission_contract.py
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check apps/api/app/api/dependencies/auth.py apps/api/app/api/v1/routes/api_key.py apps/api/app/api/v1/routes/billing.py apps/api/app/api/v1/routes/demo.py apps/api/app/api/v1/routes/documents.py apps/api/app/api/v1/routes/jobs.py apps/api/app/api/v1/routes/webhook.py apps/api/app/api/v1/routes/webhook_secrets.py apps/api/app/services/auth/current_user_authentication_service.py apps/api/app/services/auth/dashboard_jwt_authentication_service.py apps/api/tests/contract/test_dashboard_token_permission_contract.py