### PR TITLE
Enable self-hosted telemetry by default

### DIFF
--- a/apps/api/tests/contract/test_self_hosted_telemetry_contract.py
+++ b/apps/api/tests/contract/test_self_hosted_telemetry_contract.py
@@ -12,6 +12,10 @@ from typing import Any, cast
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from shared.core.config.base import (
+    DEFAULT_TELEMETRY_POSTHOG_PROJECT_KEY,
+    BaseConfig,
+)
 from shared.services.telemetry.client import TelemetryClient
 from shared.services.telemetry.config import TelemetryRuntimeConfig
 from shared.services.telemetry.api_metrics import ApiRequestTelemetryMetrics
@@ -96,6 +100,34 @@ def test_aggregate_event_names_are_allowed() -> None:
         "self_hosted_api_aggregate",
         "self_hosted_provider_aggregate",
     }.issubset(get_allowed_telemetry_event_names())
+
+
+def test_self_hosted_telemetry_defaults_to_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("TELEMETRY_ENABLED", raising=False)
+    monkeypatch.delenv("TELEMETRY_POSTHOG_HOST", raising=False)
+    monkeypatch.delenv("TELEMETRY_POSTHOG_PROJECT_KEY", raising=False)
+    monkeypatch.delenv("NEXT_PUBLIC_POSTHOG_KEY", raising=False)
+
+    config = BaseConfig(_env_file=None, TMP_PATH="/tmp/knowhere")
+
+    assert config.TELEMETRY_ENABLED is True
+    assert config.TELEMETRY_POSTHOG_HOST == "https://us.i.posthog.com"
+    assert config.TELEMETRY_POSTHOG_PROJECT_KEY == DEFAULT_TELEMETRY_POSTHOG_PROJECT_KEY
+
+
+def test_self_hosted_telemetry_env_can_disable_and_override_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TELEMETRY_ENABLED", "false")
+    monkeypatch.setenv("TELEMETRY_POSTHOG_PROJECT_KEY", "phc_test_override")
+    monkeypatch.setenv("NEXT_PUBLIC_POSTHOG_KEY", "phc_next_public_should_not_win")
+
+    config = BaseConfig(_env_file=None, TMP_PATH="/tmp/knowhere")
+
+    assert config.TELEMETRY_ENABLED is False
+    assert config.TELEMETRY_POSTHOG_PROJECT_KEY == "phc_test_override"
 
 
 def test_aggregate_properties_strip_sensitive_values() -> None:

--- a/packages/shared-python/shared/core/config/base.py
+++ b/packages/shared-python/shared/core/config/base.py
@@ -7,6 +7,11 @@ from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
+DEFAULT_TELEMETRY_POSTHOG_PROJECT_KEY = (
+    "phc_nWXdQnhvJFcjcvVNjQ8J8LhDYa9uvHfYhiuovf4Fzq64"
+)
+
+
 class BaseConfig(BaseSettings):
     """Base application configuration."""
 
@@ -34,7 +39,7 @@ class BaseConfig(BaseSettings):
         default="", description="Logfire API token for distributed tracing"
     )
     TELEMETRY_ENABLED: bool = Field(
-        default=False,
+        default=True,
         description="Enable anonymous product telemetry for self-hosted deployments",
     )
     TELEMETRY_POSTHOG_HOST: str = Field(
@@ -42,7 +47,10 @@ class BaseConfig(BaseSettings):
         description="PostHog ingestion host for anonymous telemetry events",
     )
     TELEMETRY_POSTHOG_PROJECT_KEY: str = Field(
-        default_factory=lambda: os.getenv("NEXT_PUBLIC_POSTHOG_KEY", ""),
+        default_factory=lambda: os.getenv(
+            "NEXT_PUBLIC_POSTHOG_KEY",
+            DEFAULT_TELEMETRY_POSTHOG_PROJECT_KEY,
+        ),
         description="PostHog project token for anonymous telemetry events",
     )
     TELEMETRY_INSTALLATION_ID: str = Field(


### PR DESCRIPTION
## Summary
- enable anonymous self-hosted telemetry by default in shared runtime config
- hard-code Knowhere's PostHog US Cloud host and project key as built-in runtime defaults
- keep source quickstart env examples untouched: no telemetry host/key/id/enable configuration is shown to users
- add contract coverage for default-enabled telemetry and env override behavior

## Verification
- `uv run --python 3.11 --all-packages pytest apps/api/tests/contract/test_self_hosted_telemetry_contract.py -q`
- `make lint`
- `make typecheck`
- `uv run --all-packages --group lint ruff format --check apps/api/tests/contract/test_self_hosted_telemetry_contract.py packages/shared-python/shared/core/config/base.py`
- `git diff --check`
- temporary local Gitleaks 8.30.1 arm64 binary: no leaks found
