### PR TITLE
Add document list pagination

### DIFF
--- a/apps/api/alembic/versions/fae1b2c3d4e5_add_document_list_order_index.py
+++ b/apps/api/alembic/versions/fae1b2c3d4e5_add_document_list_order_index.py
@@ -1,0 +1,32 @@
+"""add document list order index
+
+Revision ID: fae1b2c3d4e5
+Revises: f9d0e1f2a3b4
+Create Date: 2026-06-30 07:15:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "fae1b2c3d4e5"
+down_revision: Union[str, Sequence[str], None] = "f9d0e1f2a3b4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_documents_user_namespace_status_updated
+        ON documents (user_id, namespace, status, updated_at DESC, document_id ASC)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_documents_user_namespace_status_updated")

--- a/apps/api/app/api/v1/routes/documents.py
+++ b/apps/api/app/api/v1/routes/documents.py
@@ -86,6 +86,10 @@ async def list_document_chunks(
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(50, ge=1, le=200, description="Items per page"),
     chunk_type: DocumentChunkType | None = Query(None, description="Chunk type filter"),
+    include_asset_urls: bool = Query(
+        True,
+        description="Generate 7-day asset URLs for image/table chunks",
+    ),
     current_user: CurrentUser = Depends(with_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -96,6 +100,7 @@ async def list_document_chunks(
         page=page,
         page_size=page_size,
         chunk_type=chunk_type,
+        include_asset_urls=include_asset_urls,
     )
     if response is None:
         raise NotFoundException(
@@ -110,6 +115,10 @@ async def list_document_chunks(
 async def get_document_chunk(
     document_id: str,
     document_chunk_id: str,
+    include_asset_urls: bool = Query(
+        True,
+        description="Generate 7-day asset URLs for image/table chunks",
+    ),
     current_user: CurrentUser = Depends(with_current_user),
     db: AsyncSession = Depends(get_db),
 ):
@@ -118,6 +127,7 @@ async def get_document_chunk(
         user_id=current_user.user_id,
         document_id=document_id,
         document_chunk_id=document_chunk_id,
+        include_asset_urls=include_asset_urls,
     )
     if response is None:
         raise NotFoundException(

--- a/apps/api/app/api/v1/routes/documents.py
+++ b/apps/api/app/api/v1/routes/documents.py
@@ -87,8 +87,8 @@ async def list_document_chunks(
     page_size: int = Query(50, ge=1, le=200, description="Items per page"),
     chunk_type: DocumentChunkType | None = Query(None, description="Chunk type filter"),
     include_asset_urls: bool = Query(
-        True,
-        description="Generate 7-day asset URLs for image/table chunks",
+        False,
+        description="Generate 7-day asset URLs for image/table chunks when true",
     ),
     current_user: CurrentUser = Depends(with_current_user),
     db: AsyncSession = Depends(get_db),
@@ -116,8 +116,8 @@ async def get_document_chunk(
     document_id: str,
     document_chunk_id: str,
     include_asset_urls: bool = Query(
-        True,
-        description="Generate 7-day asset URLs for image/table chunks",
+        False,
+        description="Generate 7-day asset URLs for image/table chunks when true",
     ),
     current_user: CurrentUser = Depends(with_current_user),
     db: AsyncSession = Depends(get_db),

--- a/apps/api/app/api/v1/routes/documents.py
+++ b/apps/api/app/api/v1/routes/documents.py
@@ -44,19 +44,20 @@ async def _archive_document_response(
 @router.get("")
 async def list_documents(
     namespace: str | None = Query(None, max_length=255),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(50, ge=1, le=200, description="Items per page"),
     current_user: CurrentUser = Depends(with_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     effective_namespace = normalize_retrieval_namespace(namespace)
-    documents = await _document_service.list_documents(
+    response = await _document_service.list_documents(
         db,
         user_id=current_user.user_id,
         namespace=effective_namespace,
+        page=page,
+        page_size=page_size,
     )
-    return {
-        "namespace": effective_namespace,
-        "documents": documents,
-    }
+    return response
 
 
 @router.get("/{document_id}")

--- a/apps/api/app/repositories/document_repository.py
+++ b/apps/api/app/repositories/document_repository.py
@@ -23,15 +23,34 @@ class DocumentRepository:
         *,
         user_id: str,
         namespace: str,
+        limit: int,
+        offset: int,
     ) -> Sequence[Document]:
         result = await db.execute(
             select(Document)
             .where(Document.user_id == user_id)
             .where(Document.namespace == namespace)
             .where(Document.status != "archived")
-            .order_by(Document.updated_at.desc())
+            .order_by(Document.updated_at.desc(), Document.document_id.asc())
+            .limit(limit)
+            .offset(offset)
         )
         return result.scalars().all()
+
+    async def count_by_user_namespace(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: str,
+        namespace: str,
+    ) -> int:
+        result = await db.execute(
+            select(func.count(Document.document_id))
+            .where(Document.user_id == user_id)
+            .where(Document.namespace == namespace)
+            .where(Document.status != "archived")
+        )
+        return int(result.scalar_one())
 
     async def get_document(
         self,

--- a/apps/api/app/services/documents/lifecycle_service.py
+++ b/apps/api/app/services/documents/lifecycle_service.py
@@ -53,13 +53,31 @@ class DocumentService:
         *,
         user_id: str,
         namespace: str,
-    ) -> list[dict[str, Any]]:
-        documents = await self._repository.list_by_user_namespace(
+        page: int,
+        page_size: int,
+    ) -> dict[str, Any]:
+        total = await self._repository.count_by_user_namespace(
             db,
             user_id=user_id,
             namespace=namespace,
         )
-        return [document_payload(document) for document in documents]
+        documents = await self._repository.list_by_user_namespace(
+            db,
+            user_id=user_id,
+            namespace=namespace,
+            limit=page_size,
+            offset=(page - 1) * page_size,
+        )
+        return {
+            "namespace": namespace,
+            "documents": [document_payload(document) for document in documents],
+            "pagination": {
+                "page": page,
+                "page_size": page_size,
+                "total": total,
+                "total_pages": math.ceil(total / page_size) if total else 0,
+            },
+        }
 
     async def list_document_chunks(
         self,

--- a/apps/api/app/services/documents/lifecycle_service.py
+++ b/apps/api/app/services/documents/lifecycle_service.py
@@ -15,10 +15,40 @@ from shared.services.retrieval.cache_service import (
     invalidate_retrieval_cache_namespaces,
 )
 from shared.services.retrieval.graph.service import DocumentGraphService, GraphScope
+from shared.services.storage.result_storage import get_result_storage
+
+_DOCUMENT_CHUNK_ASSET_URL_EXPIRES_SECONDS = 7 * 24 * 60 * 60
+_MEDIA_CHUNK_TYPES = frozenset({"image", "table"})
 
 
 def _datetime_payload(value: datetime | None) -> str | None:
     return value.isoformat() if value else None
+
+
+def _document_chunk_asset_url(
+    *,
+    chunk_type: str,
+    job_id: str | None,
+    file_path: str | None,
+    include_asset_urls: bool,
+) -> str | None:
+    if (
+        not include_asset_urls
+        or chunk_type not in _MEDIA_CHUNK_TYPES
+        or not job_id
+        or not file_path
+    ):
+        return None
+
+    try:
+        return get_result_storage().generate_artifact_url(
+            job_id=job_id,
+            artifact_ref=file_path,
+            expires_in=_DOCUMENT_CHUNK_ASSET_URL_EXPIRES_SECONDS,
+        )
+    except Exception as exc:
+        logger.warning(f"Failed to generate document chunk asset URL (ignored): {exc}")
+        return None
 
 
 def document_payload(document) -> dict[str, Any]:
@@ -88,6 +118,7 @@ class DocumentService:
         page: int,
         page_size: int,
         chunk_type: str | None,
+        include_asset_urls: bool,
     ) -> dict[str, Any] | None:
         document = await self._repository.get_document(
             db,
@@ -132,6 +163,8 @@ class DocumentService:
             self._chunk_payload(
                 chunk=chunk,
                 section=section,
+                job_id=job_result.job_id,
+                include_asset_urls=include_asset_urls,
             )
             for chunk, section, job_result in rows
         ]
@@ -158,6 +191,7 @@ class DocumentService:
         user_id: str,
         document_id: str,
         document_chunk_id: str,
+        include_asset_urls: bool,
     ) -> dict[str, Any] | None:
         document = await self._repository.get_document(
             db,
@@ -185,6 +219,8 @@ class DocumentService:
             "chunk": self._chunk_payload(
                 chunk=chunk,
                 section=section,
+                job_id=job_result.job_id,
+                include_asset_urls=include_asset_urls,
             ),
         }
 
@@ -209,6 +245,8 @@ class DocumentService:
         *,
         chunk: DocumentChunk,
         section: DocumentSection | None,
+        job_id: str | None,
+        include_asset_urls: bool,
     ) -> dict[str, Any]:
         chunk_type = _normalize_chunk_type(chunk.chunk_type)
         file_path = chunk.file_path
@@ -223,6 +261,12 @@ class DocumentService:
             "file_path": file_path,
             "sort_order": chunk.sort_order,
             "metadata": chunk.chunk_metadata,
+            "asset_url": _document_chunk_asset_url(
+                chunk_type=chunk_type,
+                job_id=job_id,
+                file_path=file_path,
+                include_asset_urls=include_asset_urls,
+            ),
             "created_at": _datetime_payload(chunk.created_at),
         }
 

--- a/apps/api/app/services/documents/lifecycle_service.py
+++ b/apps/api/app/services/documents/lifecycle_service.py
@@ -15,7 +15,7 @@ from shared.services.retrieval.cache_service import (
     invalidate_retrieval_cache_namespaces,
 )
 from shared.services.retrieval.graph.service import DocumentGraphService, GraphScope
-from shared.services.storage.result_storage import get_result_storage
+from shared.services.storage.result_storage import ResultStorage, get_result_storage
 
 _DOCUMENT_CHUNK_ASSET_URL_EXPIRES_SECONDS = 7 * 24 * 60 * 60
 _MEDIA_CHUNK_TYPES = frozenset({"image", "table"})
@@ -31,17 +31,19 @@ def _document_chunk_asset_url(
     job_id: str | None,
     file_path: str | None,
     include_asset_urls: bool,
+    result_storage: ResultStorage | None,
 ) -> str | None:
     if (
         not include_asset_urls
         or chunk_type not in _MEDIA_CHUNK_TYPES
         or not job_id
         or not file_path
+        or result_storage is None
     ):
         return None
 
     try:
-        return get_result_storage().generate_artifact_url(
+        return result_storage.generate_artifact_url(
             job_id=job_id,
             artifact_ref=file_path,
             expires_in=_DOCUMENT_CHUNK_ASSET_URL_EXPIRES_SECONDS,
@@ -159,12 +161,14 @@ class DocumentService:
             offset=(page - 1) * page_size,
             chunk_type=normalized_chunk_type,
         )
+        result_storage = get_result_storage() if include_asset_urls else None
         chunks = [
             self._chunk_payload(
                 chunk=chunk,
                 section=section,
                 job_id=job_result.job_id,
                 include_asset_urls=include_asset_urls,
+                result_storage=result_storage,
             )
             for chunk, section, job_result in rows
         ]
@@ -211,6 +215,7 @@ class DocumentService:
             return None
 
         chunk, section, job_result = row
+        result_storage = get_result_storage() if include_asset_urls else None
         return {
             "document_id": document.document_id,
             "namespace": document.namespace,
@@ -221,6 +226,7 @@ class DocumentService:
                 section=section,
                 job_id=job_result.job_id,
                 include_asset_urls=include_asset_urls,
+                result_storage=result_storage,
             ),
         }
 
@@ -247,6 +253,7 @@ class DocumentService:
         section: DocumentSection | None,
         job_id: str | None,
         include_asset_urls: bool,
+        result_storage: ResultStorage | None,
     ) -> dict[str, Any]:
         chunk_type = _normalize_chunk_type(chunk.chunk_type)
         file_path = chunk.file_path
@@ -266,6 +273,7 @@ class DocumentService:
                 job_id=job_id,
                 file_path=file_path,
                 include_asset_urls=include_asset_urls,
+                result_storage=result_storage,
             ),
             "created_at": _datetime_payload(chunk.created_at),
         }

--- a/apps/api/tests/contract/test_documents_contract.py
+++ b/apps/api/tests/contract/test_documents_contract.py
@@ -548,14 +548,74 @@ async def test_should_list_only_the_authenticated_users_documents_for_the_effect
     assert default_namespace_json == {
         "namespace": "default",
         "documents": [],
+        "pagination": {
+            "page": 1,
+            "page_size": 50,
+            "total": 0,
+            "total_pages": 0,
+        },
     }
     assert named_namespace_json["namespace"] == "contract-documents"
+    assert named_namespace_json["pagination"] == {
+        "page": 1,
+        "page_size": 50,
+        "total": 2,
+        "total_pages": 1,
+    }
     assert [document["document_id"] for document in documents] == [
         owned_second_document_id,
         owned_first_document_id,
     ]
     assert all(document["namespace"] == "contract-documents" for document in documents)
     assert all(document["status"] == "active" for document in documents)
+
+
+@pytest.mark.asyncio
+async def test_should_paginate_documents_for_the_effective_namespace(
+    developer_api_client_factory: Callable[
+        [], AbstractAsyncContextManager[AsyncClient]
+    ],
+) -> None:
+    async with developer_api_client_factory() as api_client:
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        oldest_document_id = f"doc_{uuid4().hex[:12]}"
+        middle_document_id = f"doc_{uuid4().hex[:12]}"
+        newest_document_id = f"doc_{uuid4().hex[:12]}"
+        await _insert_document(
+            document_id=oldest_document_id,
+            updated_at=now - timedelta(minutes=10),
+        )
+        await _insert_document(
+            document_id=middle_document_id,
+            updated_at=now - timedelta(minutes=5),
+        )
+        await _insert_document(
+            document_id=newest_document_id,
+            updated_at=now,
+        )
+
+        response = await api_client.get(
+            "/api/v1/documents",
+            params={
+                "namespace": "contract-documents",
+                "page": 2,
+                "page_size": 1,
+            },
+        )
+
+    assert response.status_code == 200
+
+    response_json = cast(dict[str, object], response.json())
+    documents = cast(list[dict[str, object]], response_json["documents"])
+
+    assert response_json["namespace"] == "contract-documents"
+    assert response_json["pagination"] == {
+        "page": 2,
+        "page_size": 1,
+        "total": 3,
+        "total_pages": 3,
+    }
+    assert [document["document_id"] for document in documents] == [middle_document_id]
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/contract/test_documents_contract.py
+++ b/apps/api/tests/contract/test_documents_contract.py
@@ -746,9 +746,73 @@ async def test_should_list_current_document_chunks_by_document_id(
             "file_path": None,
             "sort_order": 0,
             "metadata": {"summary": "Intro", "page_nums": []},
+            "asset_url": None,
             "created_at": chunks[0]["created_at"],
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_should_include_media_asset_urls_in_document_chunk_list(
+    developer_api_client_factory: Callable[
+        [], AbstractAsyncContextManager[AsyncClient]
+    ],
+) -> None:
+    document_id = f"doc_{uuid4().hex[:12]}"
+    text_chunk_id = f"dchk_{uuid4().hex[:12]}"
+    table_chunk_id = f"dchk_{uuid4().hex[:12]}"
+
+    async with developer_api_client_factory() as api_client:
+        revision = await _insert_document_revision_with_chunks(
+            document_id=document_id,
+            chunks=[
+                {
+                    "id": text_chunk_id,
+                    "chunk_id": "parser-text",
+                    "chunk_type": "text",
+                    "content": "Text chunk content",
+                    "source_chunk_path": "Chapter 1/Text",
+                    "metadata": {"summary": "Text", "page_nums": []},
+                },
+                {
+                    "id": table_chunk_id,
+                    "chunk_id": "parser-table",
+                    "chunk_type": "table",
+                    "content": "| A | B |",
+                    "source_chunk_path": "Chapter 1/Table",
+                    "file_path": "tables/table-1.html",
+                    "metadata": {"summary": "Table", "page_nums": []},
+                },
+            ],
+        )
+        response = await api_client.get(
+            f"/api/v1/documents/{document_id}/chunks",
+            params={"page": 1, "page_size": 2},
+        )
+        opt_out_response = await api_client.get(
+            f"/api/v1/documents/{document_id}/chunks",
+            params={
+                "page": 1,
+                "page_size": 2,
+                "include_asset_urls": "false",
+            },
+        )
+
+    assert response.status_code == 200
+    chunks = cast(list[dict[str, object]], response.json()["chunks"])
+    expected_asset_url = (
+        "filesystem://knowhere-test-results/"
+        f"results/{revision['job_id']}/tables/table-1.html"
+        "?method=GET&expires_in=604800"
+    )
+    assert chunks[0]["asset_url"] is None
+    assert chunks[1]["asset_url"] == expected_asset_url
+
+    assert opt_out_response.status_code == 200
+    opt_out_chunks = cast(
+        list[dict[str, object]], opt_out_response.json()["chunks"]
+    )
+    assert opt_out_chunks[1]["asset_url"] is None
 
 
 @pytest.mark.asyncio
@@ -824,6 +888,11 @@ async def test_should_return_one_document_chunk_by_document_chunk_id(
     assert chunk["section_path"] == "Chapter 1"
     assert chunk["source_chunk_path"] == "Chapter 1/Figure"
     assert chunk["file_path"] == "images/figure-1.png"
+    assert chunk["asset_url"] == (
+        "filesystem://knowhere-test-results/"
+        f"results/{revision['job_id']}/images/figure-1.png"
+        "?method=GET&expires_in=604800"
+    )
     assert chunk["metadata"] == {"summary": "Figure", "page_nums": []}
     assert chunk["created_at"]
 

--- a/apps/api/tests/contract/test_documents_contract.py
+++ b/apps/api/tests/contract/test_documents_contract.py
@@ -753,7 +753,7 @@ async def test_should_list_current_document_chunks_by_document_id(
 
 
 @pytest.mark.asyncio
-async def test_should_include_media_asset_urls_in_document_chunk_list(
+async def test_should_include_media_asset_urls_in_document_chunk_list_when_requested(
     developer_api_client_factory: Callable[
         [], AbstractAsyncContextManager[AsyncClient]
     ],
@@ -787,14 +787,17 @@ async def test_should_include_media_asset_urls_in_document_chunk_list(
         )
         response = await api_client.get(
             f"/api/v1/documents/{document_id}/chunks",
-            params={"page": 1, "page_size": 2},
+            params={
+                "page": 1,
+                "page_size": 2,
+                "include_asset_urls": "true",
+            },
         )
-        opt_out_response = await api_client.get(
+        default_response = await api_client.get(
             f"/api/v1/documents/{document_id}/chunks",
             params={
                 "page": 1,
                 "page_size": 2,
-                "include_asset_urls": "false",
             },
         )
 
@@ -808,11 +811,11 @@ async def test_should_include_media_asset_urls_in_document_chunk_list(
     assert chunks[0]["asset_url"] is None
     assert chunks[1]["asset_url"] == expected_asset_url
 
-    assert opt_out_response.status_code == 200
-    opt_out_chunks = cast(
-        list[dict[str, object]], opt_out_response.json()["chunks"]
+    assert default_response.status_code == 200
+    default_chunks = cast(
+        list[dict[str, object]], default_response.json()["chunks"]
     )
-    assert opt_out_chunks[1]["asset_url"] is None
+    assert default_chunks[1]["asset_url"] is None
 
 
 @pytest.mark.asyncio
@@ -869,12 +872,19 @@ async def test_should_return_one_document_chunk_by_document_chunk_id(
         )
         response = await api_client.get(
             f"/api/v1/documents/{document_id}/chunks/{chunk_id}",
+            params={"include_asset_urls": "true"},
+        )
+        default_response = await api_client.get(
+            f"/api/v1/documents/{document_id}/chunks/{chunk_id}",
         )
 
     assert response.status_code == 200
+    assert default_response.status_code == 200
 
     response_json = cast(dict[str, object], response.json())
     chunk = cast(dict[str, object], response_json["chunk"])
+    default_response_json = cast(dict[str, object], default_response.json())
+    default_chunk = cast(dict[str, object], default_response_json["chunk"])
 
     assert response_json["document_id"] == document_id
     assert response_json["namespace"] == "contract-documents"
@@ -893,6 +903,7 @@ async def test_should_return_one_document_chunk_by_document_chunk_id(
         f"results/{revision['job_id']}/images/figure-1.png"
         "?method=GET&expires_in=604800"
     )
+    assert default_chunk["asset_url"] is None
     assert chunk["metadata"] == {"summary": "Figure", "page_nums": []}
     assert chunk["created_at"]
 


### PR DESCRIPTION
## Summary
- Add `page` and `page_size` query params to `GET /v1/documents`
- Return document-list pagination metadata matching the chunk-list response style
- Add a count query and paged document query ordered by `updated_at desc`, `document_id asc`
- Cover default and second-page behavior in document contract tests

## Verification
- `uv run pytest apps/api/tests/contract/test_documents_contract.py -q`
- `make lint`
- `make typecheck`
- `git diff --check`