### PR TITLE
fix: pin Trixie Docker base and use Java 21

### DIFF
--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -1,6 +1,6 @@
 # API Dockerfile with a multi-stage build
-# Use the official Python base image
-FROM python:3.12-slim AS builder
+# Pin Debian Trixie explicitly so package resolution is deterministic.
+FROM python:3.12-slim-trixie AS builder
 
 WORKDIR /app
 
@@ -31,8 +31,8 @@ RUN \
     UV_PROJECT_ENVIRONMENT=/app/venv uv sync --locked --no-dev
 
 # Runtime stage
-# Use the official Python base image
-FROM python:3.12-slim
+# Pin Debian Trixie explicitly so package resolution is deterministic.
+FROM python:3.12-slim-trixie
 
 WORKDIR /app
 

--- a/deploy/docker/Dockerfile.worker
+++ b/deploy/docker/Dockerfile.worker
@@ -1,6 +1,6 @@
 # Worker Dockerfile with a multi-stage build
-# Use the official Python base image
-FROM python:3.12-slim AS builder
+# Pin Debian Trixie explicitly; Trixie provides OpenJDK 21 for tabula-py.
+FROM python:3.12-slim-trixie AS builder
 
 WORKDIR /app
 
@@ -34,8 +34,8 @@ RUN \
     find /app/venv -type f -name "*.pyo" -delete
 
 # Runtime stage
-# Use the official Python base image
-FROM python:3.12-slim
+# Pin Debian Trixie explicitly; Trixie provides OpenJDK 21 for tabula-py.
+FROM python:3.12-slim-trixie
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libreoffice-calc \
     libreoffice-impress \
     libreoffice-writer \
-    openjdk-17-jre-headless \
+    openjdk-21-jre-headless \
     && rm -rf /var/lib/apt/lists/*
 
 # tabula-py shells out to Java for page-memory table HTML extraction.


### PR DESCRIPTION
## Summary
- Pin API and worker Docker images to python:3.12-slim-trixie instead of the floating python:3.12-slim tag
- Use openjdk-21-jre-headless in the worker image because Debian Trixie has no openjdk-17-jre-headless candidate
- Keep API and worker on the same explicit Debian suite

## Context
GitHub Actions run 28434376163 failed in the worker Build image step while installing openjdk-17-jre-headless. The API matrix leg was canceled after the worker failure.

## Verification
- docker build --pull=false --progress=plain --file deploy/docker/Dockerfile.worker --tag knowhere-worker:java21-fix .
- docker build --pull=false --progress=plain --file deploy/docker/Dockerfile.api --tag knowhere-api:trixie-fix .
- docker run --rm --entrypoint /bin/sh knowhere-worker:java21-fix -c 'java -version'
- tabula.read_pdf smoke inside knowhere-worker:java21-fix returned one DataFrame with shape (3, 2)
- API runtime import smoke inside knowhere-api:trixie-fix used /app/venv/bin/python and imported fastapi/shared
- git diff --check