### PR TITLE
fix: bound DOCX image summaries

### DIFF
--- a/apps/worker/app/services/document_parser/formats/docx/asset_accumulator.py
+++ b/apps/worker/app/services/document_parser/formats/docx/asset_accumulator.py
@@ -5,6 +5,9 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from app.services.document_parser.formats.docx.asset_store import DocxAssetStore
+from app.services.document_parser.formats.docx.image_summary_scheduler import (
+    DocxImageSummaryScheduler,
+)
 
 
 ImageHandler = Callable[
@@ -17,6 +20,7 @@ ImageHandler = Callable[
         int,
         bool,
         dict[str, dict[str, str]],
+        DocxImageSummaryScheduler,
     ],
     tuple[list[dict[str, Any]], list[list[object]], bool],
 ]
@@ -35,6 +39,12 @@ class DocxAssetAccumulator:
     _image_count: int = 0
     _table_count: int = 0
     _seen_images: dict[str, dict[str, str]] = field(default_factory=dict)
+    _image_summary_scheduler: DocxImageSummaryScheduler = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._image_summary_scheduler = DocxImageSummaryScheduler(
+            should_summarize=self.should_summary_image
+        )
 
     def append_image(
         self,
@@ -51,6 +61,7 @@ class DocxAssetAccumulator:
             self._image_count,
             self.should_summary_image,
             self._seen_images,
+            self._image_summary_scheduler,
         )
         if is_new_image:
             self._image_count += 1
@@ -75,9 +86,13 @@ class DocxAssetAccumulator:
             cell_images=cell_images,
             img_count=self._image_count,
             seen_images=self._seen_images,
+            image_summary_scheduler=self._image_summary_scheduler,
         )
         self._table_count += 1
         return headings_stack
+
+    def finalize(self) -> None:
+        self._image_summary_scheduler.run_all()
 
     def rows(self) -> list[list[object]]:
         return self._rows

--- a/apps/worker/app/services/document_parser/formats/docx/image_summary_scheduler.py
+++ b/apps/worker/app/services/document_parser/formats/docx/image_summary_scheduler.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from time import perf_counter
+from typing import Any
+
+import gevent
+from gevent.pool import Pool as GeventPool
+from loguru import logger
+
+from app.services.document_parser.support.parser_rows import (
+    COL_ASSET_TITLE,
+    COL_ENTITIES,
+    COL_SUMMARY,
+    serialize_entities,
+)
+from shared.core.config import settings
+from shared.services.ai.summary.model import AssetSummary
+
+
+@dataclass(frozen=True)
+class DocxImageSummaryTask:
+    image_hash: str
+    image_path: str
+    context: str
+    usage_task: str
+
+
+@dataclass
+class DocxImageOccurrence:
+    image_hash: str
+    image_index: str
+    row: list[object]
+    content_holder: list[Any] | None = None
+    content_index: int | None = None
+
+
+@dataclass
+class DocxImageSummaryScheduler:
+    should_summarize: bool
+    _tasks_by_hash: dict[str, DocxImageSummaryTask] = field(default_factory=dict)
+    _results_by_hash: dict[str, AssetSummary | None] = field(default_factory=dict)
+    _occurrences_by_hash: dict[str, list[DocxImageOccurrence]] = field(
+        default_factory=dict
+    )
+
+    def register_task(
+        self,
+        *,
+        image_hash: str,
+        image_path: str,
+        context: str,
+        usage_task: str,
+    ) -> None:
+        if not self.should_summarize or image_hash in self._tasks_by_hash:
+            return
+
+        self._tasks_by_hash[image_hash] = DocxImageSummaryTask(
+            image_hash=image_hash,
+            image_path=image_path,
+            context=context,
+            usage_task=usage_task,
+        )
+
+    def register_occurrence(
+        self,
+        occurrence: DocxImageOccurrence,
+    ) -> None:
+        self._occurrences_by_hash.setdefault(occurrence.image_hash, []).append(
+            occurrence
+        )
+        if occurrence.image_hash in self._results_by_hash:
+            self._apply_result(occurrence.image_hash, occurrence)
+
+    def run_for_hashes(
+        self,
+        image_hashes: Iterable[str],
+        *,
+        stage: str,
+        total_tasks: int,
+    ) -> None:
+        if not self.should_summarize:
+            return
+
+        unique_hashes = list(dict.fromkeys(image_hashes))
+        pending_tasks = [
+            self._tasks_by_hash[image_hash]
+            for image_hash in unique_hashes
+            if image_hash in self._tasks_by_hash
+            and image_hash not in self._results_by_hash
+        ]
+        if not pending_tasks:
+            return
+
+        batch_total_tasks = sum(
+            len(self._occurrences_by_hash.get(task.image_hash, []))
+            for task in pending_tasks
+        )
+        self._run_batch(
+            pending_tasks,
+            stage=stage,
+            total_tasks=batch_total_tasks or total_tasks,
+        )
+        for task in pending_tasks:
+            for occurrence in self._occurrences_by_hash.get(task.image_hash, []):
+                self._apply_result(task.image_hash, occurrence)
+
+    def run_all(self) -> None:
+        total_occurrences = sum(
+            len(occurrences) for occurrences in self._occurrences_by_hash.values()
+        )
+        self.run_for_hashes(
+            self._tasks_by_hash.keys(),
+            stage="docx.image_summaries",
+            total_tasks=total_occurrences,
+        )
+
+    def get_description(self, image_hash: str, image_index: str) -> str:
+        result = self._results_by_hash.get(image_hash)
+        if result is not None and result.summary:
+            return result.summary
+        return image_index
+
+    def _run_batch(
+        self,
+        tasks: list[DocxImageSummaryTask],
+        *,
+        stage: str,
+        total_tasks: int,
+    ) -> int:
+        max_concurrent = max(1, int(settings.DOCX_IMAGE_SUMMARY_MAX_CONCURRENT))
+        pool_size = min(max_concurrent, len(tasks))
+        start_time = perf_counter()
+        pool = GeventPool(size=pool_size)
+        greenlets = [pool.spawn(_run_summary_task, task) for task in tasks]
+        gevent.joinall(greenlets)
+
+        failed_tasks = 0
+        for task, greenlet in zip(tasks, greenlets, strict=True):
+            result = greenlet.value
+            if result is None:
+                failed_tasks += 1
+            self._results_by_hash[task.image_hash] = result
+
+        duration_ms = int((perf_counter() - start_time) * 1000)
+        logger.bind(
+            event="document_parser.docx_image_summary_batch",
+            stage=stage,
+            total_tasks=total_tasks,
+            unique_tasks=len(tasks),
+            max_concurrent=pool_size,
+            duration_ms=duration_ms,
+            failed_tasks=failed_tasks,
+        ).info("Completed DOCX image summary batch")
+        return failed_tasks
+
+    def _apply_result(
+        self,
+        image_hash: str,
+        occurrence: DocxImageOccurrence,
+    ) -> None:
+        result = self._results_by_hash.get(image_hash)
+        if result is None:
+            return
+
+        summary = result.summary or ""
+        asset_title = result.title or ""
+        summary_field = (
+            f"{occurrence.image_index}\n{summary}" if summary else occurrence.image_index
+        )
+        occurrence.row[0] = _build_image_ref(str(occurrence.row[1]), summary)
+        occurrence.row[3] = len(str(occurrence.row[0]))
+        occurrence.row[COL_SUMMARY] = summary_field
+        occurrence.row[COL_ENTITIES] = serialize_entities(result.entities)
+        occurrence.row[COL_ASSET_TITLE] = asset_title
+
+        if (
+            occurrence.content_holder is not None
+            and occurrence.content_index is not None
+        ):
+            occurrence.content_holder[occurrence.content_index] = occurrence.row[0]
+
+
+def build_fallback_image_ref(relative_path: str) -> str:
+    return _build_image_ref(relative_path, "")
+
+
+def _build_image_ref(relative_path: str, summary: str) -> str:
+    from shared.utils.chunk_refs import build_chunk_ref
+
+    img_ref = build_chunk_ref(relative_path)
+    if summary:
+        return f"\n{summary}\n{img_ref}\n"
+    return f"\n{img_ref}\n"
+
+
+def _run_summary_task(task: DocxImageSummaryTask) -> AssetSummary | None:
+    try:
+        from shared.services.ai.summary.engine import summarize
+
+        result = summarize(
+            mode="asset",
+            image_paths=[task.image_path],
+            text=task.context,
+            usage_task=task.usage_task,
+        )
+        if isinstance(result, AssetSummary):
+            return result
+        logger.warning(
+            f"Invalid DOCX image summary result type: {type(result).__name__}"
+        )
+    except Exception as exc:
+        logger.warning(
+            f"DOCX image summary failed for hash={task.image_hash[:12]}...: {exc}"
+        )
+    return None

--- a/apps/worker/app/services/document_parser/formats/docx/image_summary_scheduler.py
+++ b/apps/worker/app/services/document_parser/formats/docx/image_summary_scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from time import perf_counter
@@ -9,6 +10,7 @@ import gevent
 from gevent.pool import Pool as GeventPool
 from loguru import logger
 
+from app.services.document_parser.support.path_helpers import process_path_texts
 from app.services.document_parser.support.parser_rows import (
     COL_ASSET_TITLE,
     COL_ENTITIES,
@@ -25,6 +27,7 @@ class DocxImageSummaryTask:
     image_path: str
     context: str
     usage_task: str
+    title_path_prefix: str | None = None
 
 
 @dataclass
@@ -41,6 +44,7 @@ class DocxImageSummaryScheduler:
     should_summarize: bool
     _tasks_by_hash: dict[str, DocxImageSummaryTask] = field(default_factory=dict)
     _results_by_hash: dict[str, AssetSummary | None] = field(default_factory=dict)
+    _relative_paths_by_hash: dict[str, str] = field(default_factory=dict)
     _occurrences_by_hash: dict[str, list[DocxImageOccurrence]] = field(
         default_factory=dict
     )
@@ -52,6 +56,7 @@ class DocxImageSummaryScheduler:
         image_path: str,
         context: str,
         usage_task: str,
+        title_path_prefix: str | None = None,
     ) -> None:
         if not self.should_summarize or image_hash in self._tasks_by_hash:
             return
@@ -61,6 +66,7 @@ class DocxImageSummaryScheduler:
             image_path=image_path,
             context=context,
             usage_task=usage_task,
+            title_path_prefix=title_path_prefix,
         )
 
     def register_occurrence(
@@ -166,10 +172,16 @@ class DocxImageSummaryScheduler:
 
         summary = result.summary or ""
         asset_title = result.title or ""
+        relative_path = self._resolve_relative_path(
+            image_hash=image_hash,
+            result=result,
+            current_relative_path=str(occurrence.row[1]),
+        )
         summary_field = (
             f"{occurrence.image_index}\n{summary}" if summary else occurrence.image_index
         )
-        occurrence.row[0] = _build_image_ref(str(occurrence.row[1]), summary)
+        occurrence.row[0] = _build_image_ref(relative_path, summary)
+        occurrence.row[1] = relative_path
         occurrence.row[3] = len(str(occurrence.row[0]))
         occurrence.row[COL_SUMMARY] = summary_field
         occurrence.row[COL_ENTITIES] = serialize_entities(result.entities)
@@ -180,6 +192,41 @@ class DocxImageSummaryScheduler:
             and occurrence.content_index is not None
         ):
             occurrence.content_holder[occurrence.content_index] = occurrence.row[0]
+
+    def _resolve_relative_path(
+        self,
+        *,
+        image_hash: str,
+        result: AssetSummary,
+        current_relative_path: str,
+    ) -> str:
+        renamed_relative_path = self._relative_paths_by_hash.get(image_hash)
+        if renamed_relative_path:
+            return renamed_relative_path
+
+        task = self._tasks_by_hash.get(image_hash)
+        title = result.title or ""
+        if task is None or not task.title_path_prefix or not title:
+            return current_relative_path
+
+        new_name = process_path_texts(f"{task.title_path_prefix} {title}", last=30)
+        if not new_name:
+            return current_relative_path
+
+        image_dir = os.path.dirname(task.image_path)
+        image_extension = os.path.splitext(task.image_path)[1]
+        new_absolute_path = os.path.join(image_dir, f"{new_name}{image_extension}")
+        if task.image_path != new_absolute_path:
+            if not os.path.exists(task.image_path):
+                return current_relative_path
+            os.rename(task.image_path, new_absolute_path)
+
+        relative_dir = os.path.dirname(current_relative_path)
+        new_relative_path = f"{new_name}{image_extension}"
+        if relative_dir:
+            new_relative_path = f"{relative_dir}/{new_relative_path}"
+        self._relative_paths_by_hash[image_hash] = new_relative_path
+        return new_relative_path
 
 
 def build_fallback_image_ref(relative_path: str) -> str:

--- a/apps/worker/app/services/document_parser/formats/docx/parser.py
+++ b/apps/worker/app/services/document_parser/formats/docx/parser.py
@@ -179,6 +179,7 @@ def handle_image(
             image_path=image_asset.absolute_path,
             context=last_context,
             usage_task="parser.docx.image",
+            title_path_prefix=image_index,
         )
         image_summary_scheduler.register_occurrence(
             DocxImageOccurrence(

--- a/apps/worker/app/services/document_parser/formats/docx/parser.py
+++ b/apps/worker/app/services/document_parser/formats/docx/parser.py
@@ -6,6 +6,11 @@ from app.services.document_parser.tables.dataframe_helpers import process_dup_pa
 from app.services.document_parser.formats.docx.asset_accumulator import DocxAssetAccumulator
 from app.services.document_parser.formats.docx.asset_store import DocxAssetStore
 from app.services.document_parser.formats.docx.block_stream import iter_block_items
+from app.services.document_parser.formats.docx.image_summary_scheduler import (
+    DocxImageOccurrence,
+    DocxImageSummaryScheduler,
+    build_fallback_image_ref,
+)
 from app.services.document_parser.formats.docx.table_html import table2html
 from app.services.document_parser.support.identifiers import gen_str_codes, get_str_time
 from app.services.document_parser.assets.inline_asset import (
@@ -105,6 +110,7 @@ def handle_image(
     img_count,
     smart_summary=False,
     seen_images=None,
+    image_summary_scheduler: DocxImageSummaryScheduler | None = None,
 ):
     time_stamp = get_str_time()
 
@@ -113,8 +119,9 @@ def handle_image(
     img_hash = perceptual_hash(img_file["data"])
     if seen_images is not None and img_hash in seen_images:
         cached = seen_images[img_hash]
-        headings_stack[-1]["content"].append(cached["image_ref"])
-        df_list.append(
+        content_holder = headings_stack[-1]["content"]
+        content_holder.append(cached["image_ref"])
+        row = (
             build_image_asset_row(
                 content=cached["image_ref"],
                 relative_path=cached["img_path"],
@@ -125,6 +132,17 @@ def handle_image(
                 asset_title=cached.get("asset_title", ""),
             ).to_list()
         )
+        df_list.append(row)
+        if image_summary_scheduler is not None:
+            image_summary_scheduler.register_occurrence(
+                DocxImageOccurrence(
+                    image_hash=img_hash,
+                    image_index=cached["image_index"],
+                    row=row,
+                    content_holder=content_holder,
+                    content_index=len(content_holder) - 1,
+                )
+            )
         logger.debug(f"Skipped duplicate image (hash={img_hash[:12]}...)")
         return headings_stack, df_list, False  # False = cache hit, don't increment
 
@@ -137,73 +155,40 @@ def handle_image(
     raw_img_name = process_path_texts(
         f"image-{str(img_count + 1)} {current_heading} {last_context}", last=30
     )
-    raw_image_asset = asset_store.write_image(raw_img_name, img_ext, img_file["data"])
-
-    # LLM title + summary (optional, with fallback to last_context)
-    llm_title = None
-    llm_summary = None
-    asset_entities = ""
-    if smart_summary:
-        from shared.services.ai.summary.engine import summarize
-
-        # Asset contract (§4.1): the engine's per-type image prompt covers
-        # charts/tables/diagrams and pure-text screenshots alike (§4.2).
-        image_path = os.path.join(asset_store.image_dir, f"{raw_img_name}{img_ext}")
-        result = summarize(
-            mode="asset",
-            image_paths=[image_path],
-            text=last_context,
-            usage_task="parser.docx.image",
-        )
-        llm_title = result.title or None
-        llm_summary = result.summary or None
-        asset_entities = serialize_entities(result.entities)
-
-    # Fallback: LLM summary -> last_context -> None
-    img_summary = llm_summary or last_context or None
-    # Fallback: LLM title -> last_context -> None
-    img_title = llm_title or last_context or None
-
-    # Use LLM title alone for clean naming; fallback to heading+context
-    if llm_title:
-        img_name = process_path_texts(
-            f"image-{str(img_count + 1)} {llm_title}", last=30
-        )
-    else:
-        img_name = process_path_texts(
-            f"image-{str(img_count + 1)} {current_heading} {img_title or ''}", last=30
-        )
-    image_asset = asset_store.rename_image(raw_image_asset, img_name)
+    image_asset = asset_store.write_image(raw_img_name, img_ext, img_file["data"])
 
     temp_uid = gen_str_codes(img_hash)
 
-    # Build img_summary_field for df_list: image-n + optional summary
-    if img_summary:
-        img_summary_field = f"{image_index}\n{img_summary}"
-    else:
-        img_summary_field = image_index
-
-    img_ref = build_chunk_ref(image_asset.relative_path)
-
-    # Build image_ref for heading_stack: optional summary + image path ref
-    if img_summary:
-        image_ref = f"\n{img_summary}\n{img_ref}\n"
-    else:
-        image_ref = f"\n{img_ref}\n"
-
-    asset_title = llm_title or ""
-    headings_stack[-1]["content"].append(image_ref)
-    df_list.append(
+    img_summary_field = image_index
+    image_ref = build_fallback_image_ref(image_asset.relative_path)
+    content_holder = headings_stack[-1]["content"]
+    content_holder.append(image_ref)
+    row = (
         build_image_asset_row(
             content=image_ref,
             relative_path=image_asset.relative_path,
             summary=img_summary_field,
             know_id=temp_uid,
             addtime=time_stamp,
-            entities=asset_entities,
-            asset_title=asset_title,
         ).to_list()
     )
+    df_list.append(row)
+    if smart_summary and image_summary_scheduler is not None:
+        image_summary_scheduler.register_task(
+            image_hash=img_hash,
+            image_path=image_asset.absolute_path,
+            context=last_context,
+            usage_task="parser.docx.image",
+        )
+        image_summary_scheduler.register_occurrence(
+            DocxImageOccurrence(
+                image_hash=img_hash,
+                image_index=image_index,
+                row=row,
+                content_holder=content_holder,
+                content_index=len(content_holder) - 1,
+            )
+        )
 
     # Cache result for document-level dedup
     if seen_images is not None:
@@ -212,8 +197,9 @@ def handle_image(
             "image_ref": image_ref,
             "img_summary_field": img_summary_field,
             "temp_uid": temp_uid,
-            "entities": asset_entities,
-            "asset_title": asset_title,
+            "entities": "",
+            "asset_title": "",
+            "image_index": image_index,
         }
 
     return headings_stack, df_list, True  # True = new image processed
@@ -266,6 +252,23 @@ def _first_cols_rows(table_block, max_items=10, max_chars=20):
     return first_row_text, first_col_text
 
 
+def _format_cell_image_descriptions(
+    descriptions: list[tuple[str, str]],
+    image_summary_scheduler: DocxImageSummaryScheduler | None,
+) -> str:
+    formatted_descriptions = []
+    for image_hash, image_index in descriptions:
+        if image_summary_scheduler is None:
+            formatted_descriptions.append(f"[{image_index}]")
+        else:
+            image_description = image_summary_scheduler.get_description(
+                image_hash,
+                image_index,
+            )
+            formatted_descriptions.append(f"[{image_description}]")
+    return " ".join(formatted_descriptions)
+
+
 def handle_table(
     df_list,
     block,
@@ -278,23 +281,25 @@ def handle_table(
     cell_images=None,
     img_count=0,
     seen_images=None,
+    image_summary_scheduler: DocxImageSummaryScheduler | None = None,
 ):
     time_stamp = get_str_time()
 
     # Process cell images: save to disk + optional LLM summary
     cell_image_map = {}  # {(row, col): "description text"} for table2html
     table_img_entries = []  # df_list entries for images
+    table_image_hashes: list[str] = []
+    table_cell_descriptions: dict[tuple[int, int], list[tuple[str, str]]] = {}
 
     if cell_images:
         for (row_idx, col_idx), images in cell_images.items():
-            descriptions = []
+            descriptions: list[tuple[str, str]] = []
             for img_data in images:
                 # Document-level dedup: perceptual hash for visual duplicates
                 cell_img_hash = perceptual_hash(img_data["data"])
                 if seen_images is not None and cell_img_hash in seen_images:
                     cached = seen_images[cell_img_hash]
-                    descriptions.append(f"[{cached['img_summary_field']}]")
-                    table_img_entries.append(
+                    row = (
                         build_image_asset_row(
                             content=cached["image_ref"],
                             relative_path=cached["img_path"],
@@ -305,6 +310,17 @@ def handle_table(
                             asset_title=cached.get("asset_title", ""),
                         ).to_list()
                     )
+                    table_img_entries.append(row)
+                    descriptions.append((cell_img_hash, cached["image_index"]))
+                    table_image_hashes.append(cell_img_hash)
+                    if image_summary_scheduler is not None:
+                        image_summary_scheduler.register_occurrence(
+                            DocxImageOccurrence(
+                                image_hash=cell_img_hash,
+                                image_index=cached["image_index"],
+                                row=row,
+                            )
+                        )
                     logger.debug(
                         f"Skipped duplicate table cell image (hash={cell_img_hash[:12]}...)"
                     )
@@ -322,53 +338,38 @@ def handle_table(
                     img_name, img_ext, img_data["data"]
                 )
 
-                # LLM summary (optional)
-                img_summary = None
-                cell_entities = ""
-                cell_title = ""
-                if summary_image:
-                    try:
-                        from shared.services.ai.summary.engine import summarize
-
-                        cell_image_path = os.path.join(
-                            asset_store.image_dir, f"{img_name}{img_ext}"
-                        )
-                        cell_result = summarize(
-                            mode="asset",
-                            image_paths=[cell_image_path],
-                            text=current_heading,
-                            usage_task="parser.docx.table_image",
-                        )
-                        img_summary = cell_result.summary or None
-                        cell_entities = serialize_entities(cell_result.entities)
-                        cell_title = cell_result.title or ""
-                    except Exception as e:
-                        logger.warning(f"Failed to summarize table image: {e}")
-
-                effective_desc = img_summary or image_index
-                descriptions.append(f"[{effective_desc}]")
+                descriptions.append((cell_img_hash, image_index))
+                table_image_hashes.append(cell_img_hash)
+                if summary_image and image_summary_scheduler is not None:
+                    image_summary_scheduler.register_task(
+                        image_hash=cell_img_hash,
+                        image_path=image_asset.absolute_path,
+                        context=current_heading,
+                        usage_task="parser.docx.table_image",
+                    )
 
                 # Also add as IMAGE entry in df_list for indexing
                 temp_uid = gen_str_codes(cell_img_hash)
-                img_summary_field = (
-                    f"{image_index}\n{img_summary}" if img_summary else image_index
-                )
-                img_ref = build_chunk_ref(image_asset.relative_path)
-                if img_summary:
-                    image_ref = f"\n{img_summary}\n{img_ref}\n"
-                else:
-                    image_ref = f"\n{img_ref}\n"
-                table_img_entries.append(
+                img_summary_field = image_index
+                image_ref = build_fallback_image_ref(image_asset.relative_path)
+                row = (
                     build_image_asset_row(
                         content=image_ref,
                         relative_path=image_asset.relative_path,
                         summary=img_summary_field,
                         know_id=temp_uid,
                         addtime=time_stamp,
-                        entities=cell_entities,
-                        asset_title=cell_title,
                     ).to_list()
                 )
+                table_img_entries.append(row)
+                if image_summary_scheduler is not None:
+                    image_summary_scheduler.register_occurrence(
+                        DocxImageOccurrence(
+                            image_hash=cell_img_hash,
+                            image_index=image_index,
+                            row=row,
+                        )
+                    )
 
                 # Cache result for document-level dedup
                 if seen_images is not None:
@@ -377,11 +378,25 @@ def handle_table(
                         "image_ref": image_ref,
                         "img_summary_field": img_summary_field,
                         "temp_uid": temp_uid,
-                        "entities": cell_entities,
-                        "asset_title": cell_title,
+                        "entities": "",
+                        "asset_title": "",
+                        "image_index": image_index,
                     }
 
-            cell_image_map[(row_idx, col_idx)] = " ".join(descriptions)
+            table_cell_descriptions[(row_idx, col_idx)] = descriptions
+
+        if summary_image and image_summary_scheduler is not None:
+            image_summary_scheduler.run_for_hashes(
+                table_image_hashes,
+                stage="docx.table_image_summaries",
+                total_tasks=sum(len(v) for v in cell_images.values()),
+            )
+
+        for cell_position, descriptions in table_cell_descriptions.items():
+            cell_image_map[cell_position] = _format_cell_image_descriptions(
+                descriptions,
+                image_summary_scheduler,
+            )
 
         logger.info(
             f"Extracted {sum(len(v) for v in cell_images.values())} images from table-{table_count + 1} cells"
@@ -590,6 +605,7 @@ def parse_docx(
         else:  # TODO: handle latex, etc.
             pass
 
+    asset_accumulator.finalize()
     return {"content": doc_structure}, asset_accumulator.rows()
 
 

--- a/apps/worker/tests/contract/test_docx_image_summary_contract.py
+++ b/apps/worker/tests/contract/test_docx_image_summary_contract.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import os
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("TMP_PATH", "/tmp/knowhere-test")
+os.environ.setdefault("S3_BUCKET_NAME", "test-uploads")
+os.environ.setdefault("S3_ACCESS_KEY_ID", "test")
+os.environ.setdefault("S3_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("S3_TEMP_PATH", "/tmp")
+
+import gevent  # noqa: E402
+from docx import Document  # noqa: E402
+from PIL import Image  # noqa: E402
+from pytest import MonkeyPatch  # noqa: E402
+
+from app.services.document_parser.formats.docx.asset_store import (  # noqa: E402
+    DocxAssetStore,
+)
+from app.services.document_parser.formats.docx.image_summary_scheduler import (  # noqa: E402
+    DocxImageSummaryScheduler,
+)
+from app.services.document_parser.formats.docx.parser import (  # noqa: E402
+    handle_image,
+    handle_table,
+)
+from shared.core.config import settings  # noqa: E402
+from shared.services.ai.summary.model import AssetSummary  # noqa: E402
+
+
+def test_docx_inline_image_summaries_are_bounded(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    active_calls = 0
+    max_active_calls = 0
+    call_paths: list[str] = []
+
+    def fake_summarize(**kwargs: Any) -> AssetSummary:
+        nonlocal active_calls, max_active_calls
+        active_calls += 1
+        max_active_calls = max(max_active_calls, active_calls)
+        call_paths.append(kwargs["image_paths"][0])
+        gevent.sleep(0.01)
+        active_calls -= 1
+        return AssetSummary(summary=f"summary {len(call_paths)}", title="title")
+
+    monkeypatch.setattr(settings, "DOCX_IMAGE_SUMMARY_MAX_CONCURRENT", 4)
+    monkeypatch.setattr("shared.services.ai.summary.engine.summarize", fake_summarize)
+
+    asset_store = _create_asset_store(tmp_path)
+    headings_stack = _create_headings_stack()
+    rows: list[list[object]] = []
+    seen_images: dict[str, dict[str, str]] = {}
+    scheduler = DocxImageSummaryScheduler(should_summarize=True)
+
+    for image_index in range(8):
+        _, rows, is_new_image = handle_image(
+            rows,
+            _create_image_meta(image_index),
+            asset_store,
+            headings_stack,
+            "Heading",
+            image_index,
+            smart_summary=True,
+            seen_images=seen_images,
+            image_summary_scheduler=scheduler,
+        )
+        assert is_new_image is True
+
+    scheduler.run_all()
+
+    assert len(call_paths) == 8
+    assert max_active_calls <= 4
+    assert all("summary" in str(row[0]) for row in rows)
+
+
+def test_docx_duplicate_images_share_one_summary_call(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    call_paths: list[str] = []
+
+    def fake_summarize(**kwargs: Any) -> AssetSummary:
+        call_paths.append(kwargs["image_paths"][0])
+        return AssetSummary(summary="shared duplicate summary", title="shared title")
+
+    monkeypatch.setattr(settings, "DOCX_IMAGE_SUMMARY_MAX_CONCURRENT", 4)
+    monkeypatch.setattr("shared.services.ai.summary.engine.summarize", fake_summarize)
+
+    asset_store = _create_asset_store(tmp_path)
+    headings_stack = _create_headings_stack()
+    rows: list[list[object]] = []
+    seen_images: dict[str, dict[str, str]] = {}
+    scheduler = DocxImageSummaryScheduler(should_summarize=True)
+    image_meta = _create_image_meta(1)
+
+    _, rows, first_is_new = handle_image(
+        rows,
+        image_meta,
+        asset_store,
+        headings_stack,
+        "Heading",
+        0,
+        smart_summary=True,
+        seen_images=seen_images,
+        image_summary_scheduler=scheduler,
+    )
+    _, rows, second_is_new = handle_image(
+        rows,
+        image_meta,
+        asset_store,
+        headings_stack,
+        "Heading",
+        1,
+        smart_summary=True,
+        seen_images=seen_images,
+        image_summary_scheduler=scheduler,
+    )
+
+    scheduler.run_all()
+
+    assert first_is_new is True
+    assert second_is_new is False
+    assert len(call_paths) == 1
+    assert len(rows) == 2
+    assert all("shared duplicate summary" in str(row[0]) for row in rows)
+    assert all("shared duplicate summary" in str(item) for item in headings_stack[-1]["content"][1:])
+
+
+def test_docx_summary_image_false_makes_no_image_summary_calls(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_summarize(**kwargs: Any) -> AssetSummary:
+        calls.append(kwargs["image_paths"][0])
+        return AssetSummary(summary="unexpected")
+
+    monkeypatch.setattr("shared.services.ai.summary.engine.summarize", fake_summarize)
+
+    asset_store = _create_asset_store(tmp_path)
+    headings_stack = _create_headings_stack()
+    rows: list[list[object]] = []
+    seen_images: dict[str, dict[str, str]] = {}
+    scheduler = DocxImageSummaryScheduler(should_summarize=False)
+
+    _, rows, is_new_image = handle_image(
+        rows,
+        _create_image_meta(1),
+        asset_store,
+        headings_stack,
+        "Heading",
+        0,
+        smart_summary=False,
+        seen_images=seen_images,
+        image_summary_scheduler=scheduler,
+    )
+    scheduler.run_all()
+
+    assert is_new_image is True
+    assert calls == []
+    assert rows[0][5] == "image-1"
+    assert "unexpected" not in str(rows[0][0])
+
+
+def test_docx_table_image_summary_is_applied_before_html_render(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_summarize(**kwargs: Any) -> AssetSummary:
+        calls.append(kwargs["usage_task"])
+        return AssetSummary(summary="table cell summary", title="table image title")
+
+    monkeypatch.setattr(settings, "DOCX_IMAGE_SUMMARY_MAX_CONCURRENT", 4)
+    monkeypatch.setattr("shared.services.ai.summary.engine.summarize", fake_summarize)
+
+    asset_store = _create_asset_store(tmp_path)
+    headings_stack = _create_headings_stack()
+    rows: list[list[object]] = []
+    seen_images: dict[str, dict[str, str]] = {}
+    scheduler = DocxImageSummaryScheduler(should_summarize=True)
+    table = _create_docx_table()
+
+    _, rows, next_image_count = handle_table(
+        rows,
+        table,
+        asset_store,
+        headings_stack,
+        "Heading",
+        0,
+        summary_table=False,
+        summary_image=True,
+        cell_images={(0, 1): [_create_image_meta(1)]},
+        img_count=0,
+        seen_images=seen_images,
+        image_summary_scheduler=scheduler,
+    )
+
+    assert calls == ["parser.docx.table_image"]
+    assert next_image_count == 1
+    assert rows[0][2] == "image"
+    assert rows[0][5] == "image-1\ntable cell summary"
+    assert rows[0][12] == "table image title"
+    assert rows[1][2] == "table"
+
+    table_path = tmp_path / str(rows[1][1])
+    table_html = table_path.read_text(encoding="utf-8")
+    assert "<td>first</td><td>second<br/><em>[table cell summary]</em></td>" in table_html
+
+
+def test_docx_image_summary_failure_keeps_fallback_reference(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def fake_summarize(**_: Any) -> AssetSummary:
+        raise RuntimeError("provider failed")
+
+    monkeypatch.setattr(settings, "DOCX_IMAGE_SUMMARY_MAX_CONCURRENT", 4)
+    monkeypatch.setattr("shared.services.ai.summary.engine.summarize", fake_summarize)
+
+    asset_store = _create_asset_store(tmp_path)
+    headings_stack = _create_headings_stack()
+    rows: list[list[object]] = []
+    seen_images: dict[str, dict[str, str]] = {}
+    scheduler = DocxImageSummaryScheduler(should_summarize=True)
+
+    _, rows, is_new_image = handle_image(
+        rows,
+        _create_image_meta(1),
+        asset_store,
+        headings_stack,
+        "Heading",
+        0,
+        smart_summary=True,
+        seen_images=seen_images,
+        image_summary_scheduler=scheduler,
+    )
+    scheduler.run_all()
+
+    assert is_new_image is True
+    assert rows[0][5] == "image-1"
+    assert rows[0][12] == ""
+    assert str(rows[0][0]).startswith("\n[images/")
+    assert "provider failed" not in str(rows[0][0])
+
+
+def _create_asset_store(tmp_path: Path) -> DocxAssetStore:
+    asset_store = DocxAssetStore(str(tmp_path))
+    asset_store.reset()
+    return asset_store
+
+
+def _create_headings_stack() -> list[dict[str, Any]]:
+    return [{"level": 1, "heading": "Heading", "content": ["nearby context"]}]
+
+
+def _create_image_meta(seed: int) -> dict[str, Any]:
+    return {
+        "image_name": f"image-{seed}.png",
+        "data": _create_image_bytes(seed),
+        "size": 12 * 1024,
+    }
+
+
+def _create_image_bytes(seed: int) -> bytes:
+    image = Image.new(
+        "RGB",
+        (32, 32),
+        (seed % 255, (seed * 23) % 255, (seed * 47) % 255),
+    )
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _create_docx_table() -> Any:
+    document = Document()
+    table = document.add_table(rows=1, cols=2)
+    table.cell(0, 0).text = "first"
+    table.cell(0, 1).text = "second"
+    return table

--- a/apps/worker/tests/contract/test_docx_image_summary_contract.py
+++ b/apps/worker/tests/contract/test_docx_image_summary_contract.py
@@ -78,6 +78,43 @@ def test_docx_inline_image_summaries_are_bounded(
     assert all("summary" in str(row[0]) for row in rows)
 
 
+def test_docx_inline_image_title_remains_in_searchable_path(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def fake_summarize(**_: Any) -> AssetSummary:
+        return AssetSummary(summary="revenue chart summary", title="Revenue Chart")
+
+    monkeypatch.setattr(settings, "DOCX_IMAGE_SUMMARY_MAX_CONCURRENT", 4)
+    monkeypatch.setattr("shared.services.ai.summary.engine.summarize", fake_summarize)
+
+    asset_store = _create_asset_store(tmp_path)
+    headings_stack = _create_headings_stack()
+    rows: list[list[object]] = []
+    seen_images: dict[str, dict[str, str]] = {}
+    scheduler = DocxImageSummaryScheduler(should_summarize=True)
+
+    _, rows, is_new_image = handle_image(
+        rows,
+        _create_image_meta(1),
+        asset_store,
+        headings_stack,
+        "Heading",
+        0,
+        smart_summary=True,
+        seen_images=seen_images,
+        image_summary_scheduler=scheduler,
+    )
+    scheduler.run_all()
+
+    relative_path = str(rows[0][1])
+    assert is_new_image is True
+    assert relative_path == "images/image-1 Revenue Chart.png"
+    assert "Revenue Chart" in str(rows[0][0])
+    assert rows[0][12] == "Revenue Chart"
+    assert (tmp_path / relative_path).exists()
+
+
 def test_docx_duplicate_images_share_one_summary_call(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
@@ -128,6 +165,7 @@ def test_docx_duplicate_images_share_one_summary_call(
     assert len(call_paths) == 1
     assert len(rows) == 2
     assert all("shared duplicate summary" in str(row[0]) for row in rows)
+    assert all("shared title" in str(row[1]) for row in rows)
     assert all("shared duplicate summary" in str(item) for item in headings_stack[-1]["content"][1:])
 
 
@@ -208,6 +246,7 @@ def test_docx_table_image_summary_is_applied_before_html_render(
     assert rows[0][2] == "image"
     assert rows[0][5] == "image-1\ntable cell summary"
     assert rows[0][12] == "table image title"
+    assert "table image title" not in str(rows[0][1])
     assert rows[1][2] == "table"
 
     table_path = tmp_path / str(rows[1][1])

--- a/packages/shared-python/shared/core/config/ai.py
+++ b/packages/shared-python/shared/core/config/ai.py
@@ -92,6 +92,10 @@ class AIConfig(BaseModel):
         default=8,
         description="Max concurrent gevent greenlets for parallel post-heading summary LLM calls -- image/table/text (Dashscope).",
     )
+    DOCX_IMAGE_SUMMARY_MAX_CONCURRENT: int = Field(
+        default=4,
+        description="Max concurrent local DOCX image summary VLM calls per parse job.",
+    )
     TOKEN_PRICING_TABLE_JSON: str = Field(
         default="",
         description=(


### PR DESCRIPTION
Summary: Adds per-DOCX bounded local concurrency for image summary VLM calls, preserves stable DOCX image filenames, applies table-cell image summaries before table HTML rendering, and covers dedup/disabled/failure behavior with focused worker contract tests. Verification: uv run pytest apps/worker/tests/contract/test_docx_image_summary_contract.py apps/worker/tests/contract/test_table_asset_schema_contract.py; make lint; make typecheck; git diff --check.