### PR TITLE
Expose retrieval chunk metadata

### DIFF
--- a/apps/api/tests/contract/test_job_creation_contract.py
+++ b/apps/api/tests/contract/test_job_creation_contract.py
@@ -471,9 +471,15 @@ async def test_v2_created_page_memory_job_can_query_v2_retrieval(
     assert retrieval_json["namespace"] == payload["namespace"]
     assert retrieval_json["router_used"] == "small_corpus_all"
     assert len(results) == 1
+    assert results[0]["chunk_id"] == published_chunk["chunk_id"]
     assert results[0]["chunk_type"] == "page"
+    assert results[0]["content_source"] == "summary"
     assert results[0]["content"] == "v2 page-memory retrieval policy marker"
     assert results[0]["score"] == 1.0
+    assert results[0]["source_chunk_path"] == published_chunk["section_path"]
+    assert results[0]["metadata"] == {
+        "summary": "v2 page-memory retrieval policy marker"
+    }
     assert source["document_id"] == document_id
     assert source["section_path"] == published_chunk["section_path"]
 

--- a/packages/shared-python/shared/services/retrieval/execution/response_projection.py
+++ b/packages/shared-python/shared/services/retrieval/execution/response_projection.py
@@ -58,6 +58,11 @@ async def project_public_retrieval_response(response: dict[str, Any]) -> dict[st
         for field in PUBLIC_RESULT_FIELDS:
             if field in row:
                 public_row[field] = row[field]
+        metadata = row.get('metadata')
+        if not isinstance(metadata, dict):
+            metadata = row.get('chunk_metadata')
+        if isinstance(metadata, dict):
+            public_row['metadata'] = metadata
         if 'source' in row:
             public_row['source'] = row['source']
         else:

--- a/packages/shared-python/shared/services/retrieval/hydration/row_utils.py
+++ b/packages/shared-python/shared/services/retrieval/hydration/row_utils.py
@@ -7,7 +7,14 @@ from shared.services.retrieval.search.section_filters import is_excluded_section
 
 MEDIA_CHUNK_TYPES = {'image', 'table'}
 PUBLIC_RESULT_FIELDS = {
-    'chunk_type', 'content', 'score', 'asset_url',
+    'chunk_id',
+    'chunk_type',
+    'content',
+    'content_source',
+    'score',
+    'asset_url',
+    'source_chunk_path',
+    'file_path',
 }
 PUBLIC_SOURCE_FIELDS = {
     'document_id', 'source_file_name', 'section_path',

--- a/packages/shared-python/shared/services/retrieval/search/channels.py
+++ b/packages/shared-python/shared/services/retrieval/search/channels.py
@@ -27,6 +27,7 @@ WITH scoped_chunks AS (
         dc.section_id,
         dc.chunk_type,
         dc.content,
+        dc.source_chunk_path,
         dc.file_path,
         dc.chunk_metadata,
         dc.job_result_id,

--- a/packages/shared-python/shared/services/retrieval/search/scoped_corpus.py
+++ b/packages/shared-python/shared/services/retrieval/search/scoped_corpus.py
@@ -93,6 +93,7 @@ async def load_all_scoped_chunks(
             'chunk_type': chunk.chunk_type,
             'content': chunk.content,
             'score': 1.0,
+            'source_chunk_path': chunk.source_chunk_path,
             'file_path': chunk.file_path,
             'chunk_metadata': chunk.chunk_metadata or {},
             'job_result_id': chunk.job_result_id,


### PR DESCRIPTION
## Summary
- Expose `chunk_id`, `content_source`, `source_chunk_path`, `file_path`, and public `metadata` in v2 retrieval results.
- Preserve page-memory chunk metadata through retrieval so SDK `chunkId` propagation works against the deployed API contract.
- Add contract coverage for querying a v2 page-memory job through v2 retrieval.

## Tests
- `uv run --python 3.11 --all-packages pytest apps/api/tests/contract/test_job_creation_contract.py::test_v2_created_page_memory_job_can_query_v2_retrieval -q`
- `uv run --python 3.11 --all-packages pytest apps/api/tests/contract/test_retrieval_contract.py -q`
- `uv run --python 3.11 --group lint ruff check packages/shared-python/shared/services/retrieval/hydration/row_utils.py packages/shared-python/shared/services/retrieval/execution/response_projection.py packages/shared-python/shared/services/retrieval/search/scoped_corpus.py packages/shared-python/shared/services/retrieval/search/channels.py apps/api/tests/contract/test_job_creation_contract.py`
- `git diff --check`