### PR TITLE
Drop dashboard from OSS telemetry client allowlist

### DIFF
--- a/docs/adr/0004-anonymous-self-hosted-telemetry.md
+++ b/docs/adr/0004-anonymous-self-hosted-telemetry.md
@@ -60,7 +60,8 @@ Event names use the `oss_` prefix (not `self_hosted_`). Catalog:
 - `document_type`: `pdf|docx|doc|xlsx|xls|pptx|ppt|csv|txt|md|html|image|other`
   - Extension from `job_metadata->>'source_file_name'` only; map
     `png|jpg|jpeg|gif|webp|tiff` → `image`; everything else → `other`
-- `created_by_client`: `cli|node-sdk|dashboard|notebook|mcp|api|other`
+- `created_by_client`: `cli|node-sdk|notebook|mcp|api|other`
+  - No `dashboard` client: the web dashboard does not create parse jobs.
   - From `job_metadata #>> '{document_metadata,created_by_client}'`
 - `source_type`: `file|url|other`
 

--- a/packages/shared-python/shared/services/telemetry/events.py
+++ b/packages/shared-python/shared/services/telemetry/events.py
@@ -34,7 +34,6 @@ CLIENT_NAMES = frozenset(
     {
         "cli",
         "node-sdk",
-        "dashboard",
         "notebook",
         "mcp",
         "api",


### PR DESCRIPTION
## Summary
- Remove `dashboard` from `created_by_client` allowlist in emitter + ADR-0004.
- Web dashboard does not create parse jobs, so it is not an official client identity.

Follow-up to #214 / tracking #213.

## Test plan
- [ ] Confirm `normalize_client_name(\"dashboard\")` maps to `other`
- [ ] Contract tests still pass


Made with [Cursor](https://cursor.com)