### PR TITLE
hotfix: QueuePool hygiene for prod v2026.06.18.2

### DIFF
--- a/apps/api/app/api/dependencies/current_user.py
+++ b/apps/api/app/api/dependencies/current_user.py
@@ -10,6 +10,9 @@ from app.services.rate_limit.data_structures import (
 )
 from app.services.rate_limit.job_admission_service import JobAdmissionService
 from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shared.core.database import get_db
 
 _job_admission_service = JobAdmissionService()
 
@@ -17,9 +20,11 @@ _job_admission_service = JobAdmissionService()
 async def with_current_user(
     route_context: RouteAdmissionContext = Depends(get_route_admission_context),
     user_id: str = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
 ) -> AsyncGenerator[CurrentUser, None]:
     current_user = await _job_admission_service.resolve_current_user(
         route_context=route_context,
         user_id=user_id,
+        db=db,
     )
     yield current_user

--- a/apps/api/app/services/auth/api_key_authentication_service.py
+++ b/apps/api/app/services/auth/api_key_authentication_service.py
@@ -174,21 +174,28 @@ class APIKeyAuthenticationService:
     ) -> None:
         """Update last_used_at on the request session without a nested checkout.
 
-        Redis debounce skips redundant writes within the debounce window so job
-        polls do not compete for QueuePool capacity via create_task+get_db_context.
+        Redis SET NX debounce skips redundant writes within the debounce window
+        so job polls do not compete for QueuePool via create_task+get_db_context.
         """
         debounce_key = self._get_last_used_debounce_key(api_key_id)
         try:
-            if await redis_service.exists(debounce_key):
+            acquired = await redis_service.set_nx(
+                debounce_key,
+                "1",
+                ex=_LAST_USED_DEBOUNCE_SECONDS,
+            )
+            if not acquired:
                 return
         except Exception:
             logger.warning(
-                "api_key_authentication: failed to read last-used debounce for api_key_id={}",
+                "api_key_authentication: last-used debounce failed for api_key_id={}; "
+                "updating anyway",
                 api_key_id,
             )
 
         try:
             await self._repository.update_last_used(session, api_key_id)
+            # Request-scoped sessions do not auto-commit.
             await session.commit()
         except Exception as exc:
             logger.warning(
@@ -198,16 +205,3 @@ class APIKeyAuthenticationService:
                 await session.rollback()
             except Exception:
                 pass
-            return
-
-        try:
-            await redis_service.set(
-                debounce_key,
-                "1",
-                ttl=_LAST_USED_DEBOUNCE_SECONDS,
-            )
-        except Exception:
-            logger.warning(
-                "api_key_authentication: failed to write last-used debounce for api_key_id={}",
-                api_key_id,
-            )

--- a/apps/api/app/services/auth/api_key_authentication_service.py
+++ b/apps/api/app/services/auth/api_key_authentication_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 from datetime import datetime, timezone
 
@@ -11,11 +10,11 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from shared.core.config import redis_pool_manager
-from shared.core.database import get_db_context
 from shared.services.redis.redis_service import RedisService
 from shared.utils.api_keys import hash_api_key
 
 _API_KEY_USER_CACHE_TTL_SECONDS: int = 3600
+_LAST_USED_DEBOUNCE_SECONDS: int = 300
 
 
 class APIKeyAuthenticationService:
@@ -44,8 +43,12 @@ class APIKeyAuthenticationService:
         if not api_key_record or not api_key_record.is_valid():
             return None
 
-        self._schedule_last_used_update(str(api_key_record.id))
         user_id = str(api_key_record.user_id)
+        await self._update_last_used_best_effort(
+            session,
+            redis_service,
+            str(api_key_record.id),
+        )
         await self._set_cached_user_id(
             redis_service,
             key_hash,
@@ -74,6 +77,10 @@ class APIKeyAuthenticationService:
     @staticmethod
     def _get_user_api_keys_key(user_id: str) -> str:
         return f"api-key:user-hashes:{user_id}"
+
+    @staticmethod
+    def _get_last_used_debounce_key(api_key_id: str) -> str:
+        return f"api-key:last-used-debounce:{api_key_id}"
 
     async def _get_cached_user_id(
         self,
@@ -159,20 +166,48 @@ class APIKeyAuthenticationService:
         remaining_seconds = int((expires_at_utc - now).total_seconds())
         return max(1, min(_API_KEY_USER_CACHE_TTL_SECONDS, remaining_seconds))
 
-    def _schedule_last_used_update(self, api_key_id: str) -> None:
+    async def _update_last_used_best_effort(
+        self,
+        session: AsyncSession,
+        redis_service: RedisService,
+        api_key_id: str,
+    ) -> None:
+        """Update last_used_at on the request session without a nested checkout.
+
+        Redis debounce skips redundant writes within the debounce window so job
+        polls do not compete for QueuePool capacity via create_task+get_db_context.
+        """
+        debounce_key = self._get_last_used_debounce_key(api_key_id)
         try:
-            asyncio.create_task(
-                self._update_last_used_best_effort(api_key_id),
-                name=f"api_key_last_used:{api_key_id}",
-            )
-        except Exception as exc:
+            if await redis_service.exists(debounce_key):
+                return
+        except Exception:
             logger.warning(
-                f"Failed to schedule API key last-used update (ignored): {exc}"
+                "api_key_authentication: failed to read last-used debounce for api_key_id={}",
+                api_key_id,
             )
 
-    async def _update_last_used_best_effort(self, api_key_id: str) -> None:
         try:
-            async with get_db_context() as db:
-                await self._repository.update_last_used(db, api_key_id)
+            await self._repository.update_last_used(session, api_key_id)
+            await session.commit()
         except Exception as exc:
-            logger.warning(f"Failed to update API key last-used time (ignored): {exc}")
+            logger.warning(
+                f"Failed to update API key last-used time (ignored): {exc}"
+            )
+            try:
+                await session.rollback()
+            except Exception:
+                pass
+            return
+
+        try:
+            await redis_service.set(
+                debounce_key,
+                "1",
+                ttl=_LAST_USED_DEBOUNCE_SECONDS,
+            )
+        except Exception:
+            logger.warning(
+                "api_key_authentication: failed to write last-used debounce for api_key_id={}",
+                api_key_id,
+            )

--- a/apps/api/app/services/rate_limit/job_admission_service.py
+++ b/apps/api/app/services/rate_limit/job_admission_service.py
@@ -33,8 +33,9 @@ class JobAdmissionService:
         *,
         route_context: RouteAdmissionContext,
         user_id: str,
+        db: AsyncSession | None = None,
     ) -> CurrentUser:
-        user_tier = await TierService.get_tier(user_id)
+        user_tier = await TierService.get_tier(user_id, session=db)
         self._route_policy_service.enforce_guest_api_key_scope(
             route_context=route_context,
             user_tier=user_tier,

--- a/apps/api/app/services/rate_limit/job_admission_service.py
+++ b/apps/api/app/services/rate_limit/job_admission_service.py
@@ -33,7 +33,7 @@ class JobAdmissionService:
         *,
         route_context: RouteAdmissionContext,
         user_id: str,
-        db: AsyncSession | None = None,
+        db: AsyncSession,
     ) -> CurrentUser:
         user_tier = await TierService.get_tier(user_id, session=db)
         self._route_policy_service.enforce_guest_api_key_scope(

--- a/apps/api/app/services/rate_limit/tier_service.py
+++ b/apps/api/app/services/rate_limit/tier_service.py
@@ -31,8 +31,14 @@ class TierService:
     """Manages user tier lookup, caching, and refresh."""
 
     @staticmethod
-    async def get_tier(user_id: str) -> str:
+    async def get_tier(
+        user_id: str,
+        session: AsyncSession | None = None,
+    ) -> str:
         """Return a user's tier from cache or database.
+
+        When ``session`` is provided, reuse it instead of opening a nested
+        ``get_db_context`` checkout (critical on the job-poll auth path).
 
         Missing user tier state is treated as invalid data and raises directly;
         this method never falls back to a default tier for user lookup.
@@ -42,17 +48,32 @@ class TierService:
         if cached_tier is not None:
             return cached_tier
 
-        async with get_db_context() as session:
-            try:
-                user_tier: str = await TierService._get_tier_from_db(session, user_id)
-            except NotFoundException:
-                user_tier = await TierService._initialize_missing_user_tier(
-                    session,
+        if session is not None:
+            user_tier = await TierService._resolve_tier_from_db(session, user_id)
+        else:
+            async with get_db_context() as owned_session:
+                user_tier = await TierService._resolve_tier_from_db(
+                    owned_session,
                     user_id,
                 )
 
         await TierService._set_cached_tier(redis_service, user_id, user_tier)
         return user_tier
+
+    @staticmethod
+    async def _resolve_tier_from_db(session: AsyncSession, user_id: str) -> str:
+        """Load tier from DB, initializing missing first-use billing state."""
+        try:
+            return await TierService._get_tier_from_db(session, user_id)
+        except NotFoundException:
+            user_tier = await TierService._initialize_missing_user_tier(
+                session,
+                user_id,
+            )
+            # Persist first-use init when reusing the request session
+            # (get_db_context commits on exit when we own the session).
+            await session.commit()
+            return user_tier
 
     @staticmethod
     async def refresh_tier(user_id: str, session: AsyncSession) -> str:

--- a/apps/api/app/services/rate_limit/tier_service.py
+++ b/apps/api/app/services/rate_limit/tier_service.py
@@ -49,19 +49,29 @@ class TierService:
             return cached_tier
 
         if session is not None:
-            user_tier = await TierService._resolve_tier_from_db(session, user_id)
+            user_tier = await TierService._resolve_tier_from_db(
+                session,
+                user_id,
+                commit_on_initialize=True,
+            )
         else:
             async with get_db_context() as owned_session:
                 user_tier = await TierService._resolve_tier_from_db(
                     owned_session,
                     user_id,
+                    commit_on_initialize=False,
                 )
 
         await TierService._set_cached_tier(redis_service, user_id, user_tier)
         return user_tier
 
     @staticmethod
-    async def _resolve_tier_from_db(session: AsyncSession, user_id: str) -> str:
+    async def _resolve_tier_from_db(
+        session: AsyncSession,
+        user_id: str,
+        *,
+        commit_on_initialize: bool,
+    ) -> str:
         """Load tier from DB, initializing missing first-use billing state."""
         try:
             return await TierService._get_tier_from_db(session, user_id)
@@ -70,9 +80,9 @@ class TierService:
                 session,
                 user_id,
             )
-            # Persist first-use init when reusing the request session
-            # (get_db_context commits on exit when we own the session).
-            await session.commit()
+            # Request-scoped sessions do not auto-commit; get_db_context does.
+            if commit_on_initialize:
+                await session.commit()
             return user_tier
 
     @staticmethod

--- a/apps/api/tests/unit/test_job_poll_session_hygiene.py
+++ b/apps/api/tests/unit/test_job_poll_session_hygiene.py
@@ -98,7 +98,7 @@ async def test_validate_api_key_updates_last_used_on_same_session() -> None:
     session.commit = AsyncMock()
     redis_service = AsyncMock()
     redis_service.get = AsyncMock(return_value=None)
-    redis_service.exists = AsyncMock(return_value=False)
+    redis_service.set_nx = AsyncMock(return_value=True)
     redis_service.set = AsyncMock()
     redis_service.sadd = AsyncMock()
     redis_service.ttl = AsyncMock(return_value=-2)
@@ -125,10 +125,6 @@ async def test_validate_api_key_updates_last_used_on_same_session() -> None:
             "app.services.auth.api_key_authentication_service.hash_api_key",
             return_value="hash-1",
         ),
-        patch(
-            "app.services.auth.api_key_authentication_service.get_db_context",
-            create=True,
-        ) as get_db_context_mock,
         patch("asyncio.create_task") as create_task_mock,
     ):
         user_id = await service.validate_api_key(session, "kw_test_key")
@@ -137,11 +133,10 @@ async def test_validate_api_key_updates_last_used_on_same_session() -> None:
     repository.update_last_used.assert_awaited_once_with(session, "key-1")
     session.commit.assert_awaited_once()
     create_task_mock.assert_not_called()
-    get_db_context_mock.assert_not_called()
-    redis_service.set.assert_any_await(
+    redis_service.set_nx.assert_awaited_once_with(
         "api-key:last-used-debounce:key-1",
         "1",
-        ttl=300,
+        ex=300,
     )
 
 
@@ -151,7 +146,7 @@ async def test_validate_api_key_skips_last_used_when_debounced() -> None:
     session.commit = AsyncMock()
     redis_service = AsyncMock()
     redis_service.get = AsyncMock(return_value=None)
-    redis_service.exists = AsyncMock(return_value=True)
+    redis_service.set_nx = AsyncMock(return_value=False)
     redis_service.set = AsyncMock()
     redis_service.sadd = AsyncMock()
     redis_service.ttl = AsyncMock(return_value=-2)
@@ -203,7 +198,7 @@ async def test_job_poll_auth_path_uses_single_session_factory_checkout() -> None
 
     redis_service = AsyncMock()
     redis_service.get = AsyncMock(side_effect=[None, None])  # api-key miss, tier miss
-    redis_service.exists = AsyncMock(return_value=False)
+    redis_service.set_nx = AsyncMock(return_value=True)
     redis_service.set = AsyncMock()
     redis_service.sadd = AsyncMock()
     redis_service.ttl = AsyncMock(return_value=-2)

--- a/apps/api/tests/unit/test_job_poll_session_hygiene.py
+++ b/apps/api/tests/unit/test_job_poll_session_hygiene.py
@@ -1,0 +1,273 @@
+"""Regression tests: job-poll auth must not open nested DB checkouts."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from tests.support.import_environment import (
+    configure_import_environment,
+    ensure_import_paths,
+)
+
+configure_import_environment()
+ensure_import_paths()
+
+from app.services.auth.api_key_authentication_service import (  # noqa: E402
+    APIKeyAuthenticationService,
+)
+from app.services.rate_limit.data_structures import (  # noqa: E402
+    RouteAdmissionContext,
+)
+from app.services.rate_limit.job_admission_service import (  # noqa: E402
+    JobAdmissionService,
+)
+from app.services.rate_limit.tier_service import TierService  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_get_tier_reuses_provided_session_without_get_db_context() -> None:
+    session = AsyncMock()
+    redis_service = AsyncMock()
+    redis_service.get = AsyncMock(return_value=None)
+    redis_service.set = AsyncMock()
+
+    with (
+        patch(
+            "app.services.rate_limit.tier_service.redis_pool_manager.get_redis_service",
+            return_value=redis_service,
+        ),
+        patch(
+            "app.services.rate_limit.tier_service.get_db_context",
+        ) as get_db_context_mock,
+        patch.object(
+            TierService,
+            "_get_tier_from_db",
+            new=AsyncMock(return_value="pro"),
+        ) as get_tier_from_db,
+    ):
+        tier = await TierService.get_tier("user-1", session=session)
+
+    assert tier == "pro"
+    get_tier_from_db.assert_awaited_once_with(session, "user-1")
+    get_db_context_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_current_user_passes_request_session_to_get_tier() -> None:
+    session = AsyncMock()
+    route_context = RouteAdmissionContext(
+        method="GET",
+        path="/v1/jobs/job_abc",
+        limit_identifier="GET:/v1/jobs/{job_id}",
+    )
+    service = JobAdmissionService(
+        route_policy_service=MagicMock(
+            enforce_guest_api_key_scope=MagicMock(),
+            enforce_user_system_limit=AsyncMock(),
+        ),
+    )
+
+    with (
+        patch.object(
+            TierService,
+            "get_tier",
+            new=AsyncMock(return_value="free"),
+        ) as get_tier,
+        patch(
+            "app.services.rate_limit.job_admission_service.RateLimitConfig.get_instance",
+            return_value=SimpleNamespace(is_enabled=False),
+        ),
+    ):
+        current_user = await service.resolve_current_user(
+            route_context=route_context,
+            user_id="user-1",
+            db=session,
+        )
+
+    assert current_user.user_id == "user-1"
+    assert current_user.user_tier == "free"
+    get_tier.assert_awaited_once_with("user-1", session=session)
+
+
+@pytest.mark.asyncio
+async def test_validate_api_key_updates_last_used_on_same_session() -> None:
+    session = AsyncMock()
+    session.commit = AsyncMock()
+    redis_service = AsyncMock()
+    redis_service.get = AsyncMock(return_value=None)
+    redis_service.exists = AsyncMock(return_value=False)
+    redis_service.set = AsyncMock()
+    redis_service.sadd = AsyncMock()
+    redis_service.ttl = AsyncMock(return_value=-2)
+    redis_service.expire = AsyncMock()
+
+    api_key_record = SimpleNamespace(
+        id="key-1",
+        user_id="user-1",
+        expires_at=None,
+        is_valid=lambda: True,
+    )
+    repository = MagicMock()
+    repository.get_by_key_hash = AsyncMock(return_value=api_key_record)
+    repository.update_last_used = AsyncMock(return_value=True)
+
+    service = APIKeyAuthenticationService(repository=repository)
+
+    with (
+        patch(
+            "app.services.auth.api_key_authentication_service.redis_pool_manager.get_redis_service",
+            return_value=redis_service,
+        ),
+        patch(
+            "app.services.auth.api_key_authentication_service.hash_api_key",
+            return_value="hash-1",
+        ),
+        patch(
+            "app.services.auth.api_key_authentication_service.get_db_context",
+            create=True,
+        ) as get_db_context_mock,
+        patch("asyncio.create_task") as create_task_mock,
+    ):
+        user_id = await service.validate_api_key(session, "kw_test_key")
+
+    assert user_id == "user-1"
+    repository.update_last_used.assert_awaited_once_with(session, "key-1")
+    session.commit.assert_awaited_once()
+    create_task_mock.assert_not_called()
+    get_db_context_mock.assert_not_called()
+    redis_service.set.assert_any_await(
+        "api-key:last-used-debounce:key-1",
+        "1",
+        ttl=300,
+    )
+
+
+@pytest.mark.asyncio
+async def test_validate_api_key_skips_last_used_when_debounced() -> None:
+    session = AsyncMock()
+    session.commit = AsyncMock()
+    redis_service = AsyncMock()
+    redis_service.get = AsyncMock(return_value=None)
+    redis_service.exists = AsyncMock(return_value=True)
+    redis_service.set = AsyncMock()
+    redis_service.sadd = AsyncMock()
+    redis_service.ttl = AsyncMock(return_value=-2)
+    redis_service.expire = AsyncMock()
+
+    api_key_record = SimpleNamespace(
+        id="key-1",
+        user_id="user-1",
+        expires_at=None,
+        is_valid=lambda: True,
+    )
+    repository = MagicMock()
+    repository.get_by_key_hash = AsyncMock(return_value=api_key_record)
+    repository.update_last_used = AsyncMock(return_value=True)
+
+    service = APIKeyAuthenticationService(repository=repository)
+
+    with (
+        patch(
+            "app.services.auth.api_key_authentication_service.redis_pool_manager.get_redis_service",
+            return_value=redis_service,
+        ),
+        patch(
+            "app.services.auth.api_key_authentication_service.hash_api_key",
+            return_value="hash-1",
+        ),
+    ):
+        user_id = await service.validate_api_key(session, "kw_test_key")
+
+    assert user_id == "user-1"
+    repository.update_last_used.assert_not_called()
+    session.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_job_poll_auth_path_uses_single_session_factory_checkout() -> None:
+    """End-to-end hygiene: tier + last-used must not call get_db_context."""
+    session = AsyncMock()
+    session.commit = AsyncMock()
+    checkout_count = {"n": 0}
+
+    class _CountingContext:
+        async def __aenter__(self) -> Any:
+            checkout_count["n"] += 1
+            return AsyncMock()
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+    redis_service = AsyncMock()
+    redis_service.get = AsyncMock(side_effect=[None, None])  # api-key miss, tier miss
+    redis_service.exists = AsyncMock(return_value=False)
+    redis_service.set = AsyncMock()
+    redis_service.sadd = AsyncMock()
+    redis_service.ttl = AsyncMock(return_value=-2)
+    redis_service.expire = AsyncMock()
+
+    api_key_record = SimpleNamespace(
+        id="key-1",
+        user_id="user-1",
+        expires_at=None,
+        is_valid=lambda: True,
+    )
+    repository = MagicMock()
+    repository.get_by_key_hash = AsyncMock(return_value=api_key_record)
+    repository.update_last_used = AsyncMock(return_value=True)
+    auth_service = APIKeyAuthenticationService(repository=repository)
+
+    route_context = RouteAdmissionContext(
+        method="GET",
+        path="/v1/jobs/job_abc",
+        limit_identifier="GET:/v1/jobs/{job_id}",
+    )
+    admission = JobAdmissionService(
+        route_policy_service=MagicMock(
+            enforce_guest_api_key_scope=MagicMock(),
+            enforce_user_system_limit=AsyncMock(),
+        ),
+    )
+
+    with (
+        patch(
+            "app.services.auth.api_key_authentication_service.redis_pool_manager.get_redis_service",
+            return_value=redis_service,
+        ),
+        patch(
+            "app.services.rate_limit.tier_service.redis_pool_manager.get_redis_service",
+            return_value=redis_service,
+        ),
+        patch(
+            "app.services.auth.api_key_authentication_service.hash_api_key",
+            return_value="hash-1",
+        ),
+        patch(
+            "app.services.rate_limit.tier_service.get_db_context",
+            side_effect=_CountingContext,
+        ),
+        patch.object(
+            TierService,
+            "_get_tier_from_db",
+            new=AsyncMock(return_value="free"),
+        ),
+        patch(
+            "app.services.rate_limit.job_admission_service.RateLimitConfig.get_instance",
+            return_value=SimpleNamespace(is_enabled=False),
+        ),
+        patch("asyncio.create_task") as create_task_mock,
+    ):
+        user_id = await auth_service.validate_api_key(session, "kw_test_key")
+        current_user = await admission.resolve_current_user(
+            route_context=route_context,
+            user_id=user_id or "",
+            db=session,
+        )
+
+    assert current_user.user_id == "user-1"
+    assert checkout_count["n"] == 0
+    create_task_mock.assert_not_called()
+    repository.update_last_used.assert_awaited_once_with(session, "key-1")

--- a/packages/shared-python/shared/core/config/database.py
+++ b/packages/shared-python/shared/core/config/database.py
@@ -25,8 +25,10 @@ class DatabaseConfig(BaseModel):
     )
 
     # Async database pool configuration for the API.
-    DB_POOL_SIZE: int = Field(default=20, description="Connection-pool size")
-    DB_MAX_OVERFLOW: int = Field(default=30, description="Maximum overflow connections")
+    # Defaults sized for legal job-poll bursts after nested-checkout hygiene
+    # (pool_size + max_overflow = 100 checkouts per API process).
+    DB_POOL_SIZE: int = Field(default=50, description="Connection-pool size")
+    DB_MAX_OVERFLOW: int = Field(default=50, description="Maximum overflow connections")
     DB_POOL_RECYCLE: int = Field(
         default=1800, description="Connection recycle interval in seconds"
     )

--- a/packages/shared-python/shared/core/database.py
+++ b/packages/shared-python/shared/core/database.py
@@ -25,7 +25,7 @@ is_async_database_pool_disabled: bool = (
     os.getenv("DB_USE_NULL_POOL", "false").lower() == "true"
 )
 engine_options: dict[str, Any] = {
-    "pool_recycle": ProcessingConstants.DB_POOL_RECYCLE,
+    "pool_recycle": settings.DB_POOL_RECYCLE,
     "pool_pre_ping": ProcessingConstants.DB_POOL_PRE_PING,
     "pool_reset_on_return": ProcessingConstants.DB_POOL_RESET_ON_RETURN,
     "connect_args": {
@@ -46,9 +46,9 @@ if is_async_database_pool_disabled:
 else:
     engine_options.update(
         {
-            "pool_size": ProcessingConstants.DB_POOL_SIZE,
-            "max_overflow": ProcessingConstants.DB_MAX_OVERFLOW,
-            "pool_timeout": ProcessingConstants.DB_POOL_TIMEOUT,
+            "pool_size": settings.DB_POOL_SIZE,
+            "max_overflow": settings.DB_MAX_OVERFLOW,
+            "pool_timeout": settings.DB_POOL_TIMEOUT,
         }
     )
 
@@ -204,12 +204,33 @@ def setup_pool_event_listeners():
         """Handle new connection events."""
         logger.info("New database connection established")
 
-    @event.listens_for(engine.sync_engine, "checkout")
+    @event.listens_for(engine.sync_engine.pool, "checkout")
     def on_checkout(dbapi_connection, connection_record, connection_proxy):
-        """Handle connection checkout events."""
-        logger.debug("Connection checked out from pool")
+        """Handle connection checkout events and surface pool pressure."""
+        pool = engine.sync_engine.pool
+        checked_out = pool.checkedout()
+        overflow = pool.overflow()
+        pool_size = pool.size() if hasattr(pool, "size") else settings.DB_POOL_SIZE
+        logger.debug(
+            "Connection checked out from pool "
+            "(checkedout=%s overflow=%s pool_size=%s)",
+            checked_out,
+            overflow,
+            pool_size,
+        )
+        # QueuePool does not expose a first-party wait-started hook; treat
+        # checkedout >= pool_size (overflow in use) as pressure / likely wait.
+        if checked_out >= pool_size:
+            logger.warning(
+                "Database pool under pressure: checkedout=%s overflow=%s "
+                "pool_size=%s max_overflow=%s (checkout waits may exceed 1s)",
+                checked_out,
+                overflow,
+                pool_size,
+                settings.DB_MAX_OVERFLOW,
+            )
 
-    @event.listens_for(engine.sync_engine, "checkin")
+    @event.listens_for(engine.sync_engine.pool, "checkin")
     def on_checkin(dbapi_connection, connection_record):
         """Handle connection check-in events."""
         logger.debug("Connection checked in to pool")
@@ -218,6 +239,7 @@ def setup_pool_event_listeners():
     def on_invalidate(dbapi_connection, connection_record, exception):
         """Handle connection invalidation events."""
         logger.warning(f"Database connection invalidated: {exception}")
+
 
 setup_pool_event_listeners()
 
@@ -231,7 +253,7 @@ async def prewarm_connection_pool():
     logger.info("Starting connection pool prewarming...")
     try:
         # Warm the base connection pool.
-        connections_to_warm = min(ProcessingConstants.DB_POOL_SIZE, 5)
+        connections_to_warm = min(settings.DB_POOL_SIZE, 5)
         tasks = []
 
         for _ in range(connections_to_warm):

--- a/packages/shared-python/shared/services/redis/redis_service.py
+++ b/packages/shared-python/shared/services/redis/redis_service.py
@@ -111,6 +111,28 @@ class RedisService:
                 original_exception=e,
             )
 
+    async def set_nx(self, key: str, value: str, ex: int) -> bool:
+        """Atomic SET NX EX — set only if the key does not already exist.
+
+        Returns ``True`` if the key was written, ``False`` if it already existed.
+        Does not JSON-encode the value and does not fall back to a default TTL.
+        """
+        try:
+            client = await self._get_client()
+            full_key = self._build_key(key)
+
+            async def _operation():
+                return await client.set(full_key, value, nx=True, ex=ex)
+
+            return bool(await self._execute_with_retry(_operation))
+        except Exception as e:
+            logger.error(f"Redis SET NX operation failed: {e}")
+            raise RedisOperationError(
+                internal_message=f"SET NX operation failed: {str(e)}",
+                operation="SET_NX",
+                original_exception=e,
+            )
+
     async def get(self, key: str, default: Any = None) -> Any:
         """Get a key value."""
         try:

--- a/packages/shared-python/shared/tests/test_database_pool_config.py
+++ b/packages/shared-python/shared/tests/test_database_pool_config.py
@@ -1,0 +1,22 @@
+"""Unit tests for DatabaseConfig pool defaults."""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("TMP_PATH", "/tmp/knowhere-test")
+os.environ.setdefault("S3_BUCKET_NAME", "test-uploads")
+os.environ.setdefault("S3_ACCESS_KEY_ID", "test")
+os.environ.setdefault("S3_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("S3_TEMP_PATH", "/tmp")
+
+from shared.core.config.database import DatabaseConfig
+
+
+def test_database_pool_defaults_are_fifty() -> None:
+    config = DatabaseConfig(
+        DATABASE_URL="postgresql+asyncpg://test:test@localhost/test",
+    )
+    assert config.DB_POOL_SIZE == 50
+    assert config.DB_MAX_OVERFLOW == 50


### PR DESCRIPTION
## Summary
- Cherry-pick / backport of QueuePool hygiene onto the live prod cut (`v2026.06.18.2` / image `v2026.06.18.2-prod`).
- Same fix as mainline: reuse request session for tier + API-key `last_used` (Redis debounce), harden session ownership, default pool **50/50**.
- Base is `release/v2026.06.18.2` (branch created from tag `v2026.06.18.2`) so this does **not** merge into diverged `main`. Dual delivery with mainline PR; no rate-limit changes. Pair with infra env PR setting explicit `DB_POOL_SIZE`/`DB_MAX_OVERFLOW` on aws-prod.

## Test plan
- [ ] Diff vs `release/v2026.06.18.2` is only QueuePool hygiene commits (no unrelated main commits)
- [ ] Unit tests for job-poll session hygiene + pool config pass on this lineage
- [ ] Tag/build prod image from this branch after merge; deploy with infra pool env 50/50
- [ ] Smoke: concurrent job-status polls do not exhaust QueuePool; rate limits unchanged


Made with [Cursor](https://cursor.com)