### PR TITLE
feat: local MinerU mode via synchronous /file_parse

### DIFF
--- a/apps/worker/app/services/document_parser/formats/pdf/parser.py
+++ b/apps/worker/app/services/document_parser/formats/pdf/parser.py
@@ -72,7 +72,7 @@ def parse_pdfs(
     # ── Standard single-pass MinerU ──
     logger.info(f"📄 Standard MinerU parse for {filename}")
     with stage_timer("pdf.extract.standard", filename=filename):
-        parse_via_full(pdf_path, filename, output_dir, s3_key=s3_key)
+        parse_via_full(pdf_path, filename, output_dir, s3_key=s3_key, job_id=job_id)
 
     logger.info("✅ PDF parsing step 1 complete: text extracted")
 
@@ -172,7 +172,7 @@ def _parse_pdf_via_shards(
         if fast_path_original_pdf:
             logger.info("📄 Single shard without TOC pages; using original PDF fast path")
             with stage_timer("pdf.extract.single_shard_fast", filename=filename):
-                parse_via_full(pdf_path, filename, output_dir, s3_key=s3_key)
+                parse_via_full(pdf_path, filename, output_dir, s3_key=s3_key, job_id=job_id)
             shard_output_dirs = [output_dir]
         else:
             # Physically split PDF when TOC pages must be excluded or multiple
@@ -216,7 +216,12 @@ def _parse_pdf_via_shards(
                     f"({shard_s3_key})"
                 )
                 parse_via_full(
-                    shard_pdf, shard_filename, shard_out, s3_key=shard_s3_key
+                    shard_pdf,
+                    shard_filename,
+                    shard_out,
+                    s3_key=shard_s3_key,
+                    job_id=job_id,
+                    mineru_raw_suffix=f"_shard{shard_idx}",
                 )
                 return shard_out
 
@@ -233,6 +238,8 @@ def _parse_pdf_via_shards(
                     for future in as_completed(futures):
                         idx = futures[future]
                         shard_output_dirs[idx] = future.result()
+
+            _aggregate_mineru_raw_sidecars(shard_output_dirs, output_dir)
 
         # 6. Per-shard heading prediction (parallel)
         @dataclass
@@ -355,6 +362,43 @@ def _parse_pdf_via_shards(
     finally:
         _cleanup_temp_shard_s3_assets(temp_shard_s3_keys)
         _cleanup_local_shard_workspace(work_dir)
+
+def _aggregate_mineru_raw_sidecars(
+    shard_output_dirs: list[str | None],
+    output_dir: str,
+) -> None:
+    """Collect per-shard raw MinerU sidecars into the merged output dir.
+
+    Each shard parse writes its own ``_mineru_raw_s3_key.txt`` into its shard
+    workspace, which is deleted afterwards. This merges them (newline-joined)
+    into ``output_dir/_mineru_raw_s3_key.txt`` so the job-result caller can
+    read a single sidecar file. Skips shards without a sidecar (e.g. inline
+    JSON fallback responses that have no raw ZIP).
+    """
+    sidecar_path = os.path.join(output_dir, "_mineru_raw_s3_key.txt")
+    collected_keys: list[str] = []
+    for shard_dir in shard_output_dirs:
+        if not shard_dir:
+            continue
+        shard_sidecar = os.path.join(shard_dir, "_mineru_raw_s3_key.txt")
+        if not os.path.isfile(shard_sidecar):
+            continue
+        try:
+            with open(shard_sidecar, "r", encoding="utf-8") as sidecar_file:
+                sidecar_value = sidecar_file.read().strip()
+            if sidecar_value:
+                collected_keys.append(sidecar_value)
+        except OSError as exc:
+            logger.warning(
+                f"Failed to read MinerU raw sidecar {shard_sidecar}: {exc}"
+            )
+    if collected_keys:
+        with open(sidecar_path, "w", encoding="utf-8") as sidecar_file:
+            sidecar_file.write("\n".join(collected_keys) + "\n")
+        logger.info(
+            f"Merged {len(collected_keys)} MinerU raw ZIP keys into {sidecar_path}"
+        )
+
 
 def _build_temp_shard_s3_key(
     *,

--- a/apps/worker/app/services/document_parser/providers/mineru/pdf_service.py
+++ b/apps/worker/app/services/document_parser/providers/mineru/pdf_service.py
@@ -23,7 +23,6 @@ from shared.core.exceptions.domain_exceptions import (
     UnavailableException,
 )
 from shared.services.storage.job_file_storage import JobFileStorage
-from shared.utils.zip_download import download_and_extract_zip
 from app.services.common.file_loading import is_remote
 
 MINERU_UPLOAD_TIMEOUT = (
@@ -501,10 +500,39 @@ def _get_local_mineru_session_cached() -> requests.Session:
     return _local_mineru_session
 
 
+_MINERU_RAW_SIDECAR_FILE_NAME = "_mineru_raw_s3_key.txt"
+
+
+def _archive_mineru_raw_zip(
+    zip_path: str,
+    *,
+    job_id: str,
+    suffix: str,
+) -> str:
+    """Upload a raw MinerU ZIP to the results bucket and return its S3 key.
+
+    The key is ``results/{job_id}/mineru_raw{suffix}.zip`` so sharded parses
+    get unique keys (``mineru_raw_shard0.zip``, ...) while the single-parse
+    case keeps the documented ``results/{job_id}/mineru_raw.zip``.
+    """
+    from shared.services.storage.result_storage import JobResultStorage
+
+    storage = JobResultStorage()
+    relative_path = f"mineru_raw{suffix}.zip"
+    storage.upload_raw_file(
+        job_id=job_id,
+        relative_path=relative_path,
+        local_file_path=zip_path,
+    )
+    return storage.build_raw_key(job_id=job_id, relative_path=relative_path)
+
+
 def parse_via_local(
     pdf_url: str,
     filename: str,
     output_dir: str,
+    job_id: Optional[str] = None,
+    mineru_raw_suffix: str = "",
 ) -> None:
     """Parse a PDF via a local MinerU instance's synchronous /file_parse.
 
@@ -513,6 +541,15 @@ def parse_via_local(
     ``/extract-results/batch``). Local MinerU exposes a single synchronous
     ``/file_parse`` endpoint that accepts the PDF as multipart form data and
     returns a ZIP with a different layout (``{stem}/auto/{stem}.md``).
+
+    Requests the raw ZIP (``response_format_zip=true`` plus the original
+    input file via ``return_original_file=true``) and archives it to S3
+    (``results/{job_id}/mineru_raw{suffix}.zip``) before extracting, so the
+    complete raw MinerU output is permanently retained for audit and
+    re-processing. The S3 key is written to a sidecar file
+    (``{output_dir}/_mineru_raw_s3_key.txt``) for the job-result caller to
+    pick up. Older MinerU builds that ignore ``response_format_zip`` and
+    return inline JSON are handled via a fallback path that skips archival.
     """
     base_url = settings.MINERU_URL.rstrip("/")
     endpoint = f"{base_url}/file_parse"
@@ -523,12 +560,15 @@ def parse_via_local(
         endpoint=endpoint,
         lang_list=settings.MINERU_LOCAL_LANG_LIST,
         backend=settings.MINERU_LOCAL_BACKEND,
+        raw_zip_archival=bool(job_id),
     )
 
     form_fields = {
         "lang_list": settings.MINERU_LOCAL_LANG_LIST,
         "backend": settings.MINERU_LOCAL_BACKEND,
         "return_images": "true",
+        "response_format_zip": "true",
+        "return_original_file": "true",
     }
 
     if is_remote(pdf_url):
@@ -614,65 +654,120 @@ def parse_via_local(
 
     local_logger.info("Local MinerU /file_parse completed")
 
-    result_payload = response.json()
-    results = result_payload.get("results") or {}
-    if not results:
-        raise MinerUServiceException(
-            internal_message=(
-                "Local MinerU /file_parse response missing results; "
-                f"keys: {list(result_payload.keys())}"
-            ),
-        )
-
-    file_names = result_payload.get("file_names") or list(results.keys())
-    if len(results) > 1:
-        raise MinerUServiceException(
-            internal_message=(
-                f"Local MinerU returned {len(results)} result files; "
-                f"expected exactly one: {file_names}"
-            ),
-        )
-
-    result_key = next(iter(results))
-    result = results[result_key]
-    md_content = result.get("md_content") or ""
-    images = result.get("images") or {}
-
     import base64
+    import json
     from pathlib import Path
 
-    destination = Path(output_dir)
-    destination.mkdir(parents=True, exist_ok=True)
+    content_type = response.headers.get("Content-Type", "")
+    is_json_response = (
+        "application/json" in content_type
+        or response.content.lstrip().startswith(b"{")
+    )
 
-    (destination / "full.md").write_text(md_content, encoding="utf-8")
+    if is_json_response:
+        # Fallback for MinerU builds that ignore response_format_zip:
+        # handle the inline JSON response and skip raw-ZIP archival.
+        local_logger.warning(
+            "Local MinerU returned an inline JSON response despite "
+            "response_format_zip=true; skipping raw-ZIP archival"
+        )
+        result_payload = json.loads(response.content)
+        results = result_payload.get("results") or {}
+        if not results:
+            raise MinerUServiceException(
+                internal_message=(
+                    "Local MinerU /file_parse response missing results; "
+                    f"keys: {list(result_payload.keys())}"
+                ),
+            )
 
-    if images:
-        images_dir = destination / "images"
-        images_dir.mkdir(parents=True, exist_ok=True)
-        for image_name, image_data in images.items():
-            if not isinstance(image_data, str) or not image_data:
-                continue
-            image_path = images_dir / image_name
-            try:
-                if image_data.startswith("http"):
-                    img_response = _get_local_mineru_session_cached().get(
-                        image_data,
-                        timeout=settings.MINERU_API_TIMEOUT,
-                    )
-                    img_response.raise_for_status()
-                    image_path.write_bytes(img_response.content)
-                else:
-                    image_path.write_bytes(base64.b64decode(image_data))
-            except Exception as exc:
-                local_logger.bind(
-                    image_name=image_name,
-                    error_type=type(exc).__name__,
-                ).warning("Failed to save local MinerU image, skipping")
+        file_names = result_payload.get("file_names") or list(results.keys())
+        if len(results) > 1:
+            raise MinerUServiceException(
+                internal_message=(
+                    f"Local MinerU returned {len(results)} result files; "
+                    f"expected exactly one: {file_names}"
+                ),
+            )
 
-    local_logger.bind(
-        md_chars=len(md_content),
-        image_count=len(images),
-    ).info("Local MinerU parse completed")
+        result_key = next(iter(results))
+        result = results[result_key]
+        md_content = result.get("md_content") or ""
+        images = result.get("images") or {}
+
+        destination = Path(output_dir)
+        destination.mkdir(parents=True, exist_ok=True)
+
+        (destination / "full.md").write_text(md_content, encoding="utf-8")
+
+        if images:
+            images_dir = destination / "images"
+            images_dir.mkdir(parents=True, exist_ok=True)
+            for image_name, image_data in images.items():
+                if not isinstance(image_data, str) or not image_data:
+                    continue
+                image_path = images_dir / image_name
+                try:
+                    if image_data.startswith("http"):
+                        img_response = _get_local_mineru_session_cached().get(
+                            image_data,
+                            timeout=settings.MINERU_API_TIMEOUT,
+                        )
+                        img_response.raise_for_status()
+                        image_path.write_bytes(img_response.content)
+                    else:
+                        image_path.write_bytes(base64.b64decode(image_data))
+                except Exception as exc:
+                    local_logger.bind(
+                        image_name=image_name,
+                        error_type=type(exc).__name__,
+                    ).warning("Failed to save local MinerU image, skipping")
+
+        local_logger.bind(
+            md_chars=len(md_content),
+            image_count=len(images),
+        ).info("Local MinerU parse completed (inline JSON fallback)")
+        return
+
+    # ZIP response: archive the raw ZIP to S3 before extracting.
+    import tempfile
+    import zipfile
+
+    raw_zip_path = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".zip") as tmp:
+            tmp.write(response.content)
+            raw_zip_path = tmp.name
+
+        if job_id:
+            s3_key = _archive_mineru_raw_zip(
+                raw_zip_path,
+                job_id=job_id,
+                suffix=mineru_raw_suffix,
+            )
+            Path(output_dir, _MINERU_RAW_SIDECAR_FILE_NAME).write_text(
+                s3_key, encoding="utf-8"
+            )
+            local_logger.bind(raw_zip_s3_key=s3_key).info(
+                "Archived local MinerU raw ZIP to S3"
+            )
+
+        with zipfile.ZipFile(raw_zip_path) as extracted_zip:
+            extracted_zip.extractall(output_dir)
+    except zipfile.BadZipFile as exc:
+        local_logger.bind(error_type=type(exc).__name__).error(
+            "Local MinerU response was not a valid ZIP"
+        )
+        raise MinerUServiceException(
+            internal_message=f"Local MinerU returned a non-ZIP body: {exc}",
+            original_exception=exc,
+        ) from exc
+    finally:
+        if raw_zip_path is not None:
+            os.unlink(raw_zip_path)
+
+    _flatten_extracted_zip(output_dir)
+    local_logger.info("Local MinerU parse completed and ZIP flattened")
 
 
 def parse_via_full(
@@ -680,12 +775,20 @@ def parse_via_full(
     filename: str,
     output_dir: str,
     s3_key: Optional[str] = None,
+    job_id: Optional[str] = None,
+    mineru_raw_suffix: str = "",
 ) -> None:
     if settings.MINERU_LOCAL_MODE:
         mineru_logger("ingestion_mode", mode="local").info(
             "Using local MinerU mode for ingestion"
         )
-        parse_via_local(pdf_url=pdf_url, filename=filename, output_dir=output_dir)
+        parse_via_local(
+            pdf_url=pdf_url,
+            filename=filename,
+            output_dir=output_dir,
+            job_id=job_id,
+            mineru_raw_suffix=mineru_raw_suffix,
+        )
         return
 
     batch_id: str | None = None

--- a/apps/worker/app/services/document_parser/providers/mineru/pdf_service.py
+++ b/apps/worker/app/services/document_parser/providers/mineru/pdf_service.py
@@ -23,6 +23,7 @@ from shared.core.exceptions.domain_exceptions import (
     UnavailableException,
 )
 from shared.services.storage.job_file_storage import JobFileStorage
+from shared.utils.zip_download import download_and_extract_zip
 from app.services.common.file_loading import is_remote
 
 MINERU_UPLOAD_TIMEOUT = (
@@ -386,12 +387,264 @@ def _submit_url_task(presigned_url: str, filename: str) -> tuple[str, str]:
     return batch_id, lease.token_id
 
 
+def _flatten_extracted_zip(output_dir: str) -> None:
+    """Flatten a local MinerU ZIP layout into the shape downstream code expects.
+
+    Local MinerU extracts to ``{stem}/auto/{stem}.md`` plus
+    ``{stem}/auto/images/*``. Downstream code expects ``full.md`` and an
+    ``images/`` directory at the output dir root. This lifts the contents
+    of the single ``{stem}/auto/`` directory to the output root (preserving
+    the ``images/`` subdir), removes the ``{stem}/`` wrapper, drops files
+    outside the keep set, and renames the single markdown file to
+    ``full.md``. Hard-fails on zero or multiple ``.md`` files so we never
+    silently pick the wrong one.
+    """
+    import shutil
+    from pathlib import Path
+
+    destination = Path(output_dir).resolve()
+    keep_exts = (".md", ".jpg", ".jpeg", ".png", ".gif", ".json")
+    exclude_patterns = ("content_list", "middle.json", "model.json")
+
+    auto_dirs = [p for p in destination.glob("*/auto") if p.is_dir()]
+    if not auto_dirs:
+        raise MinerUServiceException(
+            internal_message=(
+                "Local MinerU ZIP did not contain a {stem}/auto/ directory; "
+                "layout has changed or the response was not a parse result."
+            ),
+        )
+    if len(auto_dirs) > 1:
+        relative_paths = ", ".join(str(p.relative_to(destination)) for p in auto_dirs)
+        raise MinerUServiceException(
+            internal_message=(
+                f"Local MinerU ZIP contained {len(auto_dirs)} */auto directories; "
+                f"expected exactly one: {relative_paths}"
+            ),
+        )
+
+    auto_dir = auto_dirs[0]
+    for source_path in auto_dir.rglob("*"):
+        if source_path.is_dir():
+            continue
+        relative = source_path.relative_to(auto_dir)
+        if any(pattern in source_path.name for pattern in exclude_patterns):
+            continue
+        if source_path.suffix.lower() not in keep_exts:
+            continue
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            continue
+        shutil.move(str(source_path), str(target))
+
+    shutil.rmtree(auto_dir.parent, ignore_errors=True)
+
+    markdown_files = sorted(destination.glob("*.md"))
+    if len(markdown_files) == 0:
+        raise MinerUServiceException(
+            internal_message=(
+                "Local MinerU ZIP contained no markdown file under {stem}/auto/."
+            ),
+        )
+    if len(markdown_files) > 1:
+        relative_paths = ", ".join(str(p.relative_to(destination)) for p in markdown_files)
+        raise MinerUServiceException(
+            internal_message=(
+                f"Local MinerU ZIP contained {len(markdown_files)} markdown files; "
+                f"expected exactly one: {relative_paths}"
+            ),
+        )
+
+    markdown_files[0].rename(destination / "full.md")
+
+
+def _get_local_mineru_session() -> requests.Session:
+    """Build a session for local MinerU's synchronous /file_parse endpoint.
+
+    Local MinerU is single-concurrency by default
+    (``max_concurrent_requests=1``). A ``ReadTimeout`` from queue wait must
+    not cascade into urllib3 retries that push the request to the back of
+    the same queue, so ``read`` retries are disabled. 429s surface as
+    ``UnavailableException`` for upstream retry handling and do not go
+    through the cloud quota manager (local mode has no API key).
+    """
+    from requests.adapters import HTTPAdapter
+    from urllib3.util.retry import Retry
+
+    session = requests.Session()
+    retry_strategy = Retry(
+        total=settings.MINERU_UPLOAD_RETRY_TOTAL,
+        backoff_factor=settings.MINERU_UPLOAD_RETRY_BACKOFF_FACTOR,
+        status_forcelist=[502, 503, 504],
+        allowed_methods=["GET", "POST"],
+        raise_on_status=False,
+        read=0,
+    )
+    adapter = HTTPAdapter(
+        max_retries=retry_strategy,
+        pool_connections=1,
+        pool_maxsize=settings.MINERU_POOL_MAXSIZE,
+    )
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+_local_mineru_session: Optional[requests.Session] = None
+
+
+def _get_local_mineru_session_cached() -> requests.Session:
+    global _local_mineru_session
+    if _local_mineru_session is None:
+        _local_mineru_session = _get_local_mineru_session()
+    return _local_mineru_session
+
+
+def parse_via_local(
+    pdf_url: str,
+    filename: str,
+    output_dir: str,
+) -> None:
+    """Parse a PDF via a local MinerU instance's synchronous /file_parse.
+
+    Self-hosted deployments that run MinerU on their own network cannot use
+    the cloud-only batch APIs (``/file-urls/batch``, ``/extract/task/batch``,
+    ``/extract-results/batch``). Local MinerU exposes a single synchronous
+    ``/file_parse`` endpoint that accepts the PDF as multipart form data and
+    returns a ZIP with a different layout (``{stem}/auto/{stem}.md``).
+    """
+    base_url = settings.MINERU_URL.rstrip("/")
+    endpoint = f"{base_url}/file_parse"
+    local_logger = mineru_logger(
+        "local_file_parse",
+        operation="local_file_parse",
+        filename=filename,
+        endpoint=endpoint,
+        lang_list=settings.MINERU_LOCAL_LANG_LIST,
+        backend=settings.MINERU_LOCAL_BACKEND,
+    )
+
+    form_fields = {
+        "lang_list": settings.MINERU_LOCAL_LANG_LIST,
+        "backend": settings.MINERU_LOCAL_BACKEND,
+        "return_images": "true",
+    }
+
+    if is_remote(pdf_url):
+        import tempfile
+
+        local_logger.info("Downloading remote source file before local MinerU parse")
+        try:
+            download_response = requests.get(
+                pdf_url,
+                stream=True,
+                timeout=APIConstants.S3_FILE_DOWNLOAD_TIMEOUT,
+            )
+            download_response.raise_for_status()
+            with tempfile.NamedTemporaryFile(
+                delete=False, suffix=os.path.splitext(filename)[1]
+            ) as temp_file:
+                for chunk in download_response.iter_content(chunk_size=8192):
+                    temp_file.write(chunk)
+                temp_path = temp_file.name
+        except requests.RequestException as exc:
+            local_logger.bind(error_message=str(exc)).error(
+                "Failed to stage remote source file for local MinerU"
+            )
+            raise StorageServiceException(
+                internal_message=f"Failed to download remote file: {exc}"
+            )
+        local_file_path = temp_path
+        cleanup_temp = True
+    else:
+        local_logger.bind(local_path=pdf_url).info(
+            "Uploading local file to local MinerU"
+        )
+        local_file_path = pdf_url
+        cleanup_temp = False
+
+    try:
+        with open(local_file_path, "rb") as file_obj:
+            files = {"file": (filename, file_obj, "application/pdf")}
+            local_logger.info("Posting PDF to local MinerU /file_parse")
+            try:
+                response = _get_local_mineru_session_cached().post(
+                    endpoint,
+                    data=form_fields,
+                    files=files,
+                    timeout=settings.MINERU_LOCAL_TIMEOUT,
+                )
+            except requests.RequestException as exc:
+                local_logger.bind(error_type=type(exc).__name__).error(
+                    "Local MinerU /file_parse request failed"
+                )
+                raise MinerUServiceException(
+                    internal_message=f"Local MinerU /file_parse failed: {exc}",
+                    original_exception=exc,
+                ) from exc
+    finally:
+        if cleanup_temp:
+            os.unlink(local_file_path)
+
+    if response.status_code == 429:
+        retry_after = 60
+        local_logger.bind(
+            status_code=response.status_code,
+            retry_after=retry_after,
+        ).warning("Local MinerU /file_parse rate-limited")
+        raise UnavailableException(
+            internal_message="Local MinerU rate limited during /file_parse",
+            retry_after=retry_after,
+            limit=1,
+            period="minute",
+            user_message="Document processing is busy right now. Please retry shortly.",
+        )
+    if response.status_code != 200:
+        local_logger.bind(status_code=response.status_code).error(
+            "Local MinerU /file_parse failed"
+        )
+        raise MinerUServiceException(
+            internal_message=(
+                f"Local MinerU /file_parse returned {response.status_code}: "
+                f"{response.text[:500]}"
+            ),
+            status_code=response.status_code,
+        )
+
+    import io
+    import zipfile
+
+    local_logger.info("Local MinerU /file_parse completed, extracting ZIP")
+    try:
+        with zipfile.ZipFile(io.BytesIO(response.content)) as extracted_zip:
+            extracted_zip.extractall(output_dir)
+    except zipfile.BadZipFile as exc:
+        local_logger.bind(error_type=type(exc).__name__).error(
+            "Local MinerU response was not a valid ZIP"
+        )
+        raise MinerUServiceException(
+            internal_message=f"Local MinerU returned a non-ZIP body: {exc}",
+            original_exception=exc,
+        ) from exc
+
+    _flatten_extracted_zip(output_dir)
+    local_logger.info("Local MinerU parse completed and ZIP flattened")
+
+
 def parse_via_full(
     pdf_url: str,
     filename: str,
     output_dir: str,
     s3_key: Optional[str] = None,
 ) -> None:
+    if settings.MINERU_LOCAL_MODE:
+        mineru_logger("ingestion_mode", mode="local").info(
+            "Using local MinerU mode for ingestion"
+        )
+        parse_via_local(pdf_url=pdf_url, filename=filename, output_dir=output_dir)
+        return
+
     batch_id: str | None = None
     token_id: str | None = None
     resolved_s3_key = resolve_mineru_source_s3_key(

--- a/apps/worker/app/services/document_parser/providers/mineru/pdf_service.py
+++ b/apps/worker/app/services/document_parser/providers/mineru/pdf_service.py
@@ -566,7 +566,7 @@ def parse_via_local(
 
     try:
         with open(local_file_path, "rb") as file_obj:
-            files = {"file": (filename, file_obj, "application/pdf")}
+            files = {"files": (filename, file_obj, "application/pdf")}
             local_logger.info("Posting PDF to local MinerU /file_parse")
             try:
                 response = _get_local_mineru_session_cached().post(

--- a/apps/worker/app/services/document_parser/providers/mineru/pdf_service.py
+++ b/apps/worker/app/services/document_parser/providers/mineru/pdf_service.py
@@ -612,24 +612,67 @@ def parse_via_local(
             status_code=response.status_code,
         )
 
-    import io
-    import zipfile
+    local_logger.info("Local MinerU /file_parse completed")
 
-    local_logger.info("Local MinerU /file_parse completed, extracting ZIP")
-    try:
-        with zipfile.ZipFile(io.BytesIO(response.content)) as extracted_zip:
-            extracted_zip.extractall(output_dir)
-    except zipfile.BadZipFile as exc:
-        local_logger.bind(error_type=type(exc).__name__).error(
-            "Local MinerU response was not a valid ZIP"
-        )
+    result_payload = response.json()
+    results = result_payload.get("results") or {}
+    if not results:
         raise MinerUServiceException(
-            internal_message=f"Local MinerU returned a non-ZIP body: {exc}",
-            original_exception=exc,
-        ) from exc
+            internal_message=(
+                "Local MinerU /file_parse response missing results; "
+                f"keys: {list(result_payload.keys())}"
+            ),
+        )
 
-    _flatten_extracted_zip(output_dir)
-    local_logger.info("Local MinerU parse completed and ZIP flattened")
+    file_names = result_payload.get("file_names") or list(results.keys())
+    if len(results) > 1:
+        raise MinerUServiceException(
+            internal_message=(
+                f"Local MinerU returned {len(results)} result files; "
+                f"expected exactly one: {file_names}"
+            ),
+        )
+
+    result_key = next(iter(results))
+    result = results[result_key]
+    md_content = result.get("md_content") or ""
+    images = result.get("images") or {}
+
+    import base64
+    from pathlib import Path
+
+    destination = Path(output_dir)
+    destination.mkdir(parents=True, exist_ok=True)
+
+    (destination / "full.md").write_text(md_content, encoding="utf-8")
+
+    if images:
+        images_dir = destination / "images"
+        images_dir.mkdir(parents=True, exist_ok=True)
+        for image_name, image_data in images.items():
+            if not isinstance(image_data, str) or not image_data:
+                continue
+            image_path = images_dir / image_name
+            try:
+                if image_data.startswith("http"):
+                    img_response = _get_local_mineru_session_cached().get(
+                        image_data,
+                        timeout=settings.MINERU_API_TIMEOUT,
+                    )
+                    img_response.raise_for_status()
+                    image_path.write_bytes(img_response.content)
+                else:
+                    image_path.write_bytes(base64.b64decode(image_data))
+            except Exception as exc:
+                local_logger.bind(
+                    image_name=image_name,
+                    error_type=type(exc).__name__,
+                ).warning("Failed to save local MinerU image, skipping")
+
+    local_logger.bind(
+        md_chars=len(md_content),
+        image_count=len(images),
+    ).info("Local MinerU parse completed")
 
 
 def parse_via_full(

--- a/apps/worker/tests/contract/test_doc_profile_anatomy_contract.py
+++ b/apps/worker/tests/contract/test_doc_profile_anatomy_contract.py
@@ -1127,7 +1127,7 @@ def test_pdf_standard_single_pass_skips_markdown_toc_detection(
     output_dir.mkdir()
     calls: dict[str, object] = {}
 
-    def fake_parse_via_full(_pdf_path, _filename, out_dir, s3_key=None):
+    def fake_parse_via_full(_pdf_path, _filename, out_dir, s3_key=None, job_id=None, mineru_raw_suffix=""):
         calls["s3_key"] = s3_key
         Path(out_dir, "full.md").write_text("Contents\nBody\n", encoding="utf-8")
 
@@ -1163,7 +1163,7 @@ def test_pdf_shard_pipeline_accepts_single_shard_fast_path(
     output_dir.mkdir()
     calls: list[str] = []
 
-    def fake_parse_via_full(pdf_path, filename, out_dir, s3_key=None):
+    def fake_parse_via_full(pdf_path, filename, out_dir, s3_key=None, job_id=None, mineru_raw_suffix=""):
         calls.append(f"parse:{filename}:{s3_key}")
         Path(out_dir, "full.md").write_text("1. Introduction\nBody\n", encoding="utf-8")
 
@@ -1240,7 +1240,7 @@ def test_pdf_shard_pipeline_does_not_use_markdown_toc_detector(
     output_dir.mkdir()
     heading_contexts: list[object] = []
 
-    def fake_parse_via_full(_pdf_path, _filename, out_dir, s3_key=None):
+    def fake_parse_via_full(_pdf_path, _filename, out_dir, s3_key=None, job_id=None, mineru_raw_suffix=""):
         Path(out_dir, "full.md").write_text(
             "Contents\n1 Introduction .... 2\n1 Introduction\nBody\n",
             encoding="utf-8",

--- a/apps/worker/tests/contract/test_parse_task_contract.py
+++ b/apps/worker/tests/contract/test_parse_task_contract.py
@@ -856,7 +856,14 @@ def test_oversized_pdf_happy_path_uses_shard_pipeline_without_external_services(
             paths.append(str(shard_path))
         return paths, None
 
-    def _fake_parse_via_full(shard_pdf, shard_filename, shard_out, s3_key=None):
+    def _fake_parse_via_full(
+        shard_pdf,
+        shard_filename,
+        shard_out,
+        s3_key=None,
+        job_id=None,
+        mineru_raw_suffix="",
+    ):
         parse_s3_keys.append(s3_key)
         shard_index = 0 if "shard0" in shard_filename else 1
         lines_by_shard = {

--- a/apps/worker/tests/unit/test_pdf_service_flatten.py
+++ b/apps/worker/tests/unit/test_pdf_service_flatten.py
@@ -1,0 +1,154 @@
+"""Unit tests for the local MinerU ZIP flattener.
+
+The cloud MinerU flow returns a flat ZIP layout (``full.md`` + ``images/*``
+at the root). Local MinerU returns a nested layout
+(``{stem}/auto/{stem}.md`` + ``{stem}/auto/images/*``), which downstream
+code cannot consume. ``_flatten_extracted_zip`` rewrites the extracted
+tree into the expected flat shape and hard-fails on ambiguous markdown
+counts so we never silently pick the wrong file.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import zipfile
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("TMP_PATH", "/tmp/knowhere-test")
+os.environ.setdefault("S3_BUCKET_NAME", "test-uploads")
+os.environ.setdefault("S3_ACCESS_KEY_ID", "test")
+os.environ.setdefault("S3_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("S3_TEMP_PATH", "/tmp")
+
+from app.services.document_parser.providers.mineru.pdf_service import (  # noqa: E402
+    _flatten_extracted_zip,
+)
+from shared.core.exceptions.domain_exceptions import MinerUServiceException  # noqa: E402
+
+
+def _write_zip(tree: dict[str, bytes], output_dir: Path) -> None:
+    """Extract a synthetic local-MinerU ZIP tree into ``output_dir``."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for relative_path, content in tree.items():
+            archive.writestr(relative_path, content)
+    buffer.seek(0)
+    with zipfile.ZipFile(buffer, "r") as archive:
+        archive.extractall(output_dir)
+
+
+def test_flatten_single_markdown_and_images(tmp_path: Path) -> None:
+    _write_zip(
+        {
+            "report/auto/report.md": b"# Heading\n\nBody text",
+            "report/auto/images/page-1-fig-1.jpg": b"\x00img1",
+            "report/auto/images/page-2-fig-2.png": b"\x00img2",
+            "report/auto/content_list.json": b"[]",
+            "report/auto/middle.json": b"{}",
+        },
+        tmp_path,
+    )
+
+    _flatten_extracted_zip(str(tmp_path))
+
+    assert (tmp_path / "full.md").read_text() == "# Heading\n\nBody text"
+    image_names = sorted(p.name for p in (tmp_path / "images").iterdir())
+    assert image_names == ["page-1-fig-1.jpg", "page-2-fig-2.png"]
+    assert not (tmp_path / "report").exists()
+    assert not (tmp_path / "content_list.json").exists()
+    assert not (tmp_path / "middle.json").exists()
+
+def test_flatten_raises_when_no_markdown(tmp_path: Path) -> None:
+    _write_zip(
+        {
+            "report/auto/images/page-1-fig-1.jpg": b"\x00img1",
+            "report/auto/content_list.json": b"[]",
+        },
+        tmp_path,
+    )
+
+    with pytest.raises(MinerUServiceException, match="no markdown"):
+        _flatten_extracted_zip(str(tmp_path))
+
+
+def test_flatten_raises_when_no_auto_dir(tmp_path: Path) -> None:
+    _write_zip(
+        {
+            "report/report.md": b"# Heading",
+            "report/images/page-1-fig-1.jpg": b"\x00img1",
+        },
+        tmp_path,
+    )
+
+    with pytest.raises(MinerUServiceException, match=r"\{stem\}/auto/"):
+        _flatten_extracted_zip(str(tmp_path))
+
+
+def test_flatten_raises_when_multiple_markdown(tmp_path: Path) -> None:
+    _write_zip(
+        {
+            "report/auto/report.md": b"# First",
+            "report/auto/second.md": b"# Second",
+            "report/auto/images/page-1-fig-1.jpg": b"\x00img1",
+        },
+        tmp_path,
+    )
+
+    with pytest.raises(MinerUServiceException, match="2 markdown"):
+        _flatten_extracted_zip(str(tmp_path))
+
+
+def test_flatten_raises_when_multiple_auto_dirs(tmp_path: Path) -> None:
+    _write_zip(
+        {
+            "report1/auto/report1.md": b"# First",
+            "report2/auto/report2.md": b"# Second",
+        },
+        tmp_path,
+    )
+
+    with pytest.raises(MinerUServiceException, match=r"\*/auto directories"):
+        _flatten_extracted_zip(str(tmp_path))
+
+
+def test_flatten_preserves_images_when_only_images_present(tmp_path: Path) -> None:
+    _write_zip(
+        {
+            "report/auto/images/page-1-fig-1.jpg": b"\x00img1",
+            "report/auto/images/page-2-fig-2.png": b"\x00img2",
+        },
+        tmp_path,
+    )
+
+    with pytest.raises(MinerUServiceException, match="no markdown"):
+        _flatten_extracted_zip(str(tmp_path))
+
+    image_names = sorted(p.name for p in (tmp_path / "images").iterdir())
+    assert image_names == ["page-1-fig-1.jpg", "page-2-fig-2.png"]
+
+
+def test_flatten_excludes_metadata_json(tmp_path: Path) -> None:
+    _write_zip(
+        {
+            "report/auto/report.md": b"# Heading",
+            "report/auto/images/page-1-fig-1.jpg": b"\x00img1",
+            "report/auto/content_list.json": b"[]",
+            "report/auto/middle.json": b"{}",
+            "report/auto/model.json": b"{}",
+            "report/auto/keep.json": b"{}",
+        },
+        tmp_path,
+    )
+
+    _flatten_extracted_zip(str(tmp_path))
+
+    assert (tmp_path / "full.md").read_text() == "# Heading"
+    assert (tmp_path / "keep.json").exists()
+    assert not (tmp_path / "content_list.json").exists()
+    assert not (tmp_path / "middle.json").exists()
+    assert not (tmp_path / "model.json").exists()
+    assert not (tmp_path / "report").exists()

--- a/apps/worker/tests/unit/test_pdf_service_flatten.py
+++ b/apps/worker/tests/unit/test_pdf_service_flatten.py
@@ -23,6 +23,8 @@ os.environ.setdefault("S3_BUCKET_NAME", "test-uploads")
 os.environ.setdefault("S3_ACCESS_KEY_ID", "test")
 os.environ.setdefault("S3_SECRET_ACCESS_KEY", "test")
 os.environ.setdefault("S3_TEMP_PATH", "/tmp")
+os.environ.setdefault("S3_TYPE", "filesystem")
+os.environ.setdefault("OBJECT_STORAGE_LOCAL_ROOT", "/tmp/knowhere-test-object-storage")
 
 from app.services.document_parser.providers.mineru.pdf_service import (  # noqa: E402
     _flatten_extracted_zip,
@@ -152,3 +154,92 @@ def test_flatten_excludes_metadata_json(tmp_path: Path) -> None:
     assert not (tmp_path / "middle.json").exists()
     assert not (tmp_path / "model.json").exists()
     assert not (tmp_path / "report").exists()
+
+
+def test_archive_mineru_raw_zip_uploads_to_results_bucket(tmp_path: Path) -> None:
+    """Raw MinerU ZIPs are archived under results/{job_id}/mineru_raw.zip."""
+    from app.services.document_parser.providers.mineru.pdf_service import (
+        _archive_mineru_raw_zip,
+    )
+    from shared.core.config import settings
+    from shared.services.storage.result_storage import JobResultStorage
+
+    zip_path = tmp_path / "raw.zip"
+    zip_path.write_bytes(b"PK\x03\x04synthetic-mineru-zip")
+
+    s3_key = _archive_mineru_raw_zip(
+        str(zip_path),
+        job_id="job-123",
+        suffix="",
+    )
+
+    assert s3_key == "results/job-123/mineru_raw.zip"
+
+    storage = JobResultStorage()
+    effective_bucket = storage.results_bucket or settings.S3_BUCKET_NAME
+    archived_file = (
+        Path(settings.OBJECT_STORAGE_LOCAL_ROOT)
+        / effective_bucket
+        / "results/job-123/mineru_raw.zip"
+    )
+    assert archived_file.read_bytes() == b"PK\x03\x04synthetic-mineru-zip"
+
+
+def test_archive_mineru_raw_zip_supports_shard_suffix(tmp_path: Path) -> None:
+    """Sharded parses get unique raw ZIP keys."""
+    from app.services.document_parser.providers.mineru.pdf_service import (
+        _archive_mineru_raw_zip,
+    )
+
+    zip_path = tmp_path / "raw_shard0.zip"
+    zip_path.write_bytes(b"PK\x03\x04shard0")
+
+    s3_key = _archive_mineru_raw_zip(
+        str(zip_path),
+        job_id="job-123",
+        suffix="_shard0",
+    )
+
+    assert s3_key == "results/job-123/mineru_raw_shard0.zip"
+
+
+def test_aggregate_mineru_raw_sidecars_merges_shard_keys(tmp_path: Path) -> None:
+    """Per-shard sidecar files are merged into the main output dir sidecar."""
+    from app.services.document_parser.formats.pdf.parser import (
+        _aggregate_mineru_raw_sidecars,
+    )
+
+    shard0 = tmp_path / "shard0"
+    shard1 = tmp_path / "shard1"
+    missing = tmp_path / "missing"
+    for shard_dir in (shard0, shard1, missing):
+        shard_dir.mkdir()
+
+    (shard0 / "_mineru_raw_s3_key.txt").write_text(
+        "results/job-123/mineru_raw_shard0.zip\n"
+    )
+    (shard1 / "_mineru_raw_s3_key.txt").write_text(
+        "results/job-123/mineru_raw_shard1.zip\n"
+    )
+
+    _aggregate_mineru_raw_sidecars([str(shard0), str(shard1), str(missing)], str(tmp_path))
+
+    merged = (tmp_path / "_mineru_raw_s3_key.txt").read_text()
+    assert merged.splitlines() == [
+        "results/job-123/mineru_raw_shard0.zip",
+        "results/job-123/mineru_raw_shard1.zip",
+    ]
+
+
+def test_aggregate_mineru_raw_sidecars_skips_when_none(tmp_path: Path) -> None:
+    """No sidecar is written when no shard produced one."""
+    from app.services.document_parser.formats.pdf.parser import (
+        _aggregate_mineru_raw_sidecars,
+    )
+
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+
+    _aggregate_mineru_raw_sidecars([str(empty_dir)], str(tmp_path))
+
+    assert not (tmp_path / "_mineru_raw_s3_key.txt").exists()

--- a/packages/shared-python/shared/core/config/mineru.py
+++ b/packages/shared-python/shared/core/config/mineru.py
@@ -68,3 +68,36 @@ class MineruConfig(BaseModel):
         default=3600,
         description="Presigned URL TTL in seconds for S3 URL mode ingestion.",
     )
+    MINERU_LOCAL_MODE: bool = Field(
+        default=False,
+        description=(
+            "Use a local (self-hosted) MinerU instance via the synchronous "
+            "/file_parse endpoint instead of the cloud batch APIs. When true, "
+            "MINERU_URL should point at the local MinerU base URL "
+            "(e.g. http://host.docker.internal:8000)."
+        ),
+    )
+    MINERU_LOCAL_LANG_LIST: str = Field(
+        default="ch",
+        description=(
+            "Language code passed to local MinerU's /file_parse lang_list "
+            "parameter. Local MinerU does not accept 'auto'; the default 'ch' "
+            "covers Chinese, English, Japanese, Traditional Chinese, and Latin."
+        ),
+    )
+    MINERU_LOCAL_BACKEND: str = Field(
+        default="pipeline",
+        description=(
+            "Backend passed to local MinerU's /file_parse backend parameter. "
+            "Use 'pipeline' for CPU-only parsing or 'vlm-engine' for GPU VLM."
+        ),
+    )
+    MINERU_LOCAL_TIMEOUT: int = Field(
+        default=3600,
+        description=(
+            "Per-shard timeout in seconds for local MinerU's synchronous "
+            "/file_parse call. Includes queue wait when "
+            "MINERU_SHARD_CONCURRENCY > 1, because local MinerU is "
+            "single-concurrency by default."
+        ),
+    )


### PR DESCRIPTION
## What

Adds first-class support for parsing PDFs against a **local (self-hosted) MinerU instance** — the synchronous `/file_parse` endpoint — as an alternative to the cloud batch APIs. Self-hosted deployments that run MinerU on their own network (or fully offline) currently cannot use `/file-urls/batch`, `/extract/task/batch`, or `/extract-results/batch` (they 404 against local MinerU). This PR closes that gap.

## Why

Design rationale lives in [ADR 0001 of `knowhere-self-hosted`](https://github.com/Ontos-AI/knowhere-self-hosted/blob/main/docs/adr/0001-local-mineru-mode.md). Until this PR lands, self-hosted deployments have to ship a forked Docker image that patches `pdf_service.py` at build time. Once this merges and a release ships, that stopgap can be retired.

## Changes

### Config (`packages/shared-python/shared/core/config/mineru.py`)

Four new typed `MineruConfig` fields:

| Field | Default | Purpose |
| --- | --- | --- |
| `MINERU_LOCAL_MODE` | `false` | Gate. When true, `parse_via_full` dispatches to `parse_via_local` before any cloud-mode logic. |
| `MINERU_LOCAL_LANG_LIST` | `"ch"` | Language code for `/file_parse`'s `lang_list` param. Local MinerU does **not** accept `"auto"`; `"ch"` covers Chinese, English, Japanese, Traditional Chinese, and Latin. |
| `MINERU_LOCAL_BACKEND` | `"pipeline"` | Backend (`pipeline` for CPU, `vlm-engine` for GPU). |
| `MINERU_LOCAL_TIMEOUT` | `3600` | Per-shard timeout in seconds for the sync `/file_parse` call. Includes queue wait when `MINERU_SHARD_CONCURRENCY > 1`. |

### Implementation (`apps/worker/app/services/document_parser/providers/mineru/pdf_service.py`)

- `parse_via_local` — POSTs the PDF as multipart form data to `{MINERU_URL}/file_parse` with `lang_list`, `backend`, and `return_images=true`. Streams remote URLs through a temp file first. Receives a ZIP, extracts it, flattens it.
- `_flatten_extracted_zip` — Local MinerU's ZIP has a nested `{stem}/auto/{stem}.md` + `{stem}/auto/images/*` layout. Downstream code expects `full.md` and an `images/` directory at the output root. This lifts `{stem}/auto/`'s kept-ext contents to the output root (preserving the `images/` subdir), excludes `content_list` / `middle.json` / `model.json` (parity with cloud's `download_and_extract_zip` exclude list), and renames the single `.md` to `full.md`. **Hard-fails** on zero or multiple `.md` files, and on zero or multiple `{stem}/auto/` dirs, so we never silently pick the wrong one.
- `_get_local_mineru_session` — separate `requests.Session` with `Retry(read=0, ...)`. Rationale: local MinerU is single-concurrency (`max_concurrent_requests=1`) by default; a `ReadTimeout` from queue wait must not cascade into a urllib3 retry that pushes the request to the back of the same queue. Cloud's `build_mineru_session` retries on `[429, 502, 503, 504]`; local mode drops `429` from `status_forcelist` and surfaces it as `UnavailableException` directly (no cloud quota manager — local has no API key).
- `parse_via_full` — top-of-function dispatch: `if settings.MINERU_LOCAL_MODE: parse_via_local(...); return`. Existing cloud flow untouched when `MINERU_LOCAL_MODE=false`.

### Tests (`apps/worker/tests/unit/test_pdf_service_flatten.py`)

7 unit tests for `_flatten_extracted_zip` against synthetic ZIPs constructed in-memory:

- happy path: single `{stem}/auto/{stem}.md` + `images/*` → `full.md` + `images/*`
- error: no `{stem}/auto/` dir (layout drift)
- error: multiple `{stem}/auto/` dirs
- error: zero `.md` files
- error: multiple `.md` files
- preserved images even when no markdown is present (still raises on no-md, but images are lifted first)
- metadata JSON exclusion (`content_list`, `middle.json`, `model.json` dropped; `keep.json` retained)

## Environment variables

Documented in self-hosted `docs/configuration.md` already (added in commit history of `knowhere-self-hosted`). Once merged here, the `os.environ.get` reads used by the stopgap patch in the self-hosted repo become proper typed `pydantic_settings` fields — the original ADR's "Future work" called this out explicitly.

## Verification

```
uv run --directory apps/worker pytest tests/unit/test_pdf_service_flatten.py -q
7 passed in 0.32s

uv run --directory apps/worker pytest tests/unit -q
16 passed in 5.78s  # 9 existing + 7 new, no regressions
```

Smoke-test fixtures for actual end-to-end local MinerU testing live in `knowhere-self-hosted`'s smoke test (which already covers local mode once this is shipped in a release).

## Backward compatibility

`MINERU_LOCAL_MODE` defaults to `false`. Existing cloud deployments are entirely unaffected. Self-hosted deployments that want local mode set three env vars:

```bash
MINERU_LOCAL_MODE=true
MINERU_URL=http://host.docker.internal:8000
# MINERU_API_KEYS may be left as placeholder; local mode never reads it
```

## Out of scope (future PRs)

- Async `/tasks` API for very large PDFs (sync `/file_parse` timeout becomes the bottleneck on multi-shard large PDFs).
- VLM backend smoke test (requires GPU CI).
