### PR TITLE
fix: accept result_mode as compatibility extra field

### DIFF
--- a/apps/api/app/services/document_ingestion/service.py
+++ b/apps/api/app/services/document_ingestion/service.py
@@ -48,7 +48,7 @@ JobMetadata = dict[str, object]
 _PUBLIC_MODE_SELECTOR_FIELDS = {"mode", "processing"}
 _PARSE_TRACK_FIELD = "parse_track"
 _PAGE_MEMORY_FIELD_PREFIX = "page_memory"
-_PUBLIC_COMPATIBILITY_EXTRA_FIELDS = frozenset({_PARSE_TRACK_FIELD})
+_PUBLIC_COMPATIBILITY_EXTRA_FIELDS = frozenset({_PARSE_TRACK_FIELD, "result_mode"})
 IngestionCommandFactory = Callable[[str], DocumentIngestionCommand]
 
 


### PR DESCRIPTION
## What

The dashboard's upload flow (`file-upload-flow.tsx`) sends `result_mode` in the job creation payload, but the API removed this field. The request is rejected with `400 Unsupported job-create fields`.

## Fix

Add `result_mode` to `_PUBLIC_COMPATIBILITY_EXTRA_FIELDS` in `apps/api/app/services/document_ingestion/service.py` so it's silently ignored instead of rejecting the whole request.

## Context

- `result_mode` was [removed from `JobMetadata`](https://github.com/Ontos-AI/knowhere/blob/main/packages/shared-python/shared/models/schemas/job_metadata.py#L39) (comment: "result_mode was removed and is no longer supported")
- The dashboard's `JobCreate` type still includes `result_mode: "auto" | "inline" | "url"` ([`server/external-api/jobs.ts`](https://github.com/Ontos-AI/knowhere-dashboard/blob/main/server/external-api/jobs.ts))
- This causes every dashboard upload to fail with `400 Bad Request` against the current API

## Verification

Tested end-to-end with a local Docker Compose deployment — uploads succeed after this fix.
