### PR TITLE
fix: truncate markdown image name context to prevent OS filename limit

### DIFF
--- a/apps/worker/app/services/document_parser/formats/markdown/image_asset.py
+++ b/apps/worker/app/services/document_parser/formats/markdown/image_asset.py
@@ -135,6 +135,7 @@ def build_markdown_image_asset(
 def build_markdown_image_name(*, image_count: int, last_context: str) -> str:
     image_name_context = path_handle(last_context.strip(), mode="clean_single")
     if image_name_context:
+        image_name_context = image_name_context[:60]
         return f"image-{image_count}-{image_name_context}"
     return f"image-{image_count}"
 


### PR DESCRIPTION
## What

When `last_context` (the markdown text preceding an image) is very long, the generated image filename exceeds the OS 255-byte limit, causing `os.rename` to fail with `OSError: [Errno 36] File name too long`.

## Error

```
OSError: [Errno 36] File name too long:
'/tmp/.../images/a68d4c...jpg' ->
'/tmp/.../images/image-1-## 5. How to determine whether an application falls within or beyond the _$500,000 threshold For EE A, whose employment contract is terminated by 1-month notice ending on 30 April 2025, the relevant date of termination of employment falls on 30 April 2025...jpg'
```

## Fix

Truncate `image_name_context` to 60 characters after sanitization in `build_markdown_image_name()`. The context is cosmetic (used in the filename for debuggability), so truncation has no functional impact.

## Verification

Tested end-to-end with a 44-page PDF that triggered the original error — parsing succeeds after this fix.
