### PR TITLE
feat: persist MinerU raw ZIP key on job results + download endpoint

### DIFF
--- a/apps/api/alembic/versions/fce1c2d3e4f6_add_mineru_raw_s3_key_to_job_results.py
+++ b/apps/api/alembic/versions/fce1c2d3e4f6_add_mineru_raw_s3_key_to_job_results.py
@@ -1,0 +1,30 @@
+"""Add mineru raw s3 key to job_results.
+
+Revision ID: fce1c2d3e4f6
+Revises: fbe1c2d3e4f5
+Create Date: 2026-08-01 09:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "fce1c2d3e4f6"
+down_revision: Union[str, Sequence[str], None] = "fbe1c2d3e4f5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "job_results",
+        sa.Column("mineru_raw_s3_key", sa.String(length=512), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("job_results", "mineru_raw_s3_key")

--- a/apps/api/app/api/v2/routes/documents.py
+++ b/apps/api/app/api/v2/routes/documents.py
@@ -37,4 +37,24 @@ async def get_document_page_citation_source(
         )
     return response
 
+
+@router.get("/{document_id}/files/mineru-raw")
+async def get_document_mineru_raw(
+    document_id: str,
+    current_user: CurrentUser = Depends(with_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    response = await _document_service.get_document_mineru_raw(
+        db,
+        user_id=current_user.user_id,
+        document_id=document_id,
+    )
+    if response is None:
+        raise NotFoundException(
+            resource="Document MinerU raw output",
+            resource_id=document_id,
+            internal_message="Document MinerU raw output not found",
+        )
+    return response
+
 __all__ = ["router"]

--- a/apps/api/app/services/documents/lifecycle_service.py
+++ b/apps/api/app/services/documents/lifecycle_service.py
@@ -31,6 +31,18 @@ def _datetime_payload(value: datetime | None) -> str | None:
     return value.isoformat() if value else None
 
 
+def _split_mineru_raw_s3_keys(value: str | None) -> list[str]:
+    """Split the stored MinerU raw key(s) into individual S3 keys.
+
+    Single-parse jobs store one key. Sharded jobs store the per-shard keys
+    newline-joined (one per line), merged by the worker from each shard's
+    sidecar file.
+    """
+    if not value:
+        return []
+    return [key.strip() for key in value.splitlines() if key.strip()]
+
+
 def _document_chunk_asset_url(
     *,
     chunk_type: str,
@@ -402,31 +414,39 @@ class DocumentService:
             return None
 
         document, job_result, job = row
-        raw_s3_key = job_result.mineru_raw_s3_key
-        if not raw_s3_key:
+        raw_s3_keys = _split_mineru_raw_s3_keys(job_result.mineru_raw_s3_key)
+        if not raw_s3_keys:
             return None
 
         result_storage = self._result_storage or get_result_storage()
-        download_url = result_storage.generate_url(
-            storage_key=raw_s3_key,
-            expires_in=_MINERU_RAW_EXPIRES_SECONDS,
-        )
-        if not download_url:
+        download_urls = []
+        for raw_s3_key in raw_s3_keys:
+            download_url = result_storage.generate_url(
+                storage_key=raw_s3_key,
+                expires_in=_MINERU_RAW_EXPIRES_SECONDS,
+            )
+            if download_url:
+                download_urls.append(download_url)
+        if not download_urls:
             return None
 
         expires_at = datetime.now(timezone.utc) + timedelta(
             seconds=_MINERU_RAW_EXPIRES_SECONDS,
         )
-        return {
+        response: dict[str, Any] = {
             "document_id": document.document_id,
             "namespace": document.namespace,
             "job_id": job.job_id,
             "job_result_id": job_result.id,
             "file_name": _MINERU_RAW_FILE_NAME,
             "content_type": "application/zip",
-            "url": download_url,
             "expires_at": expires_at.isoformat(),
         }
+        if len(download_urls) == 1:
+            response["url"] = download_urls[0]
+        else:
+            response["urls"] = download_urls
+        return response
 
     def _chunk_payload(
         self,

--- a/apps/api/app/services/documents/lifecycle_service.py
+++ b/apps/api/app/services/documents/lifecycle_service.py
@@ -23,6 +23,8 @@ _PAGE_CITATION_SOURCE_EXPIRES_SECONDS = 60 * 60
 _PAGE_CITATION_SOURCE_FILE_NAME = "source.pdf"
 _PAGE_CITATION_SOURCE_VARIANT = "normalized_pdf"
 _PAGE_MEMORY_PARSE_TRACK = "page_memory"
+_MINERU_RAW_EXPIRES_SECONDS = 7 * 24 * 60 * 60
+_MINERU_RAW_FILE_NAME = "mineru_raw.zip"
 
 
 def _datetime_payload(value: datetime | None) -> str | None:
@@ -381,6 +383,48 @@ class DocumentService:
             "file_name": _PAGE_CITATION_SOURCE_FILE_NAME,
             "content_type": "application/pdf",
             "url": source_url,
+            "expires_at": expires_at.isoformat(),
+        }
+
+    async def get_document_mineru_raw(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: str,
+        document_id: str,
+    ) -> dict[str, Any] | None:
+        row = await self._repository.get_current_document_job_revision(
+            db,
+            user_id=user_id,
+            document_id=document_id,
+        )
+        if row is None:
+            return None
+
+        document, job_result, job = row
+        raw_s3_key = job_result.mineru_raw_s3_key
+        if not raw_s3_key:
+            return None
+
+        result_storage = self._result_storage or get_result_storage()
+        download_url = result_storage.generate_url(
+            storage_key=raw_s3_key,
+            expires_in=_MINERU_RAW_EXPIRES_SECONDS,
+        )
+        if not download_url:
+            return None
+
+        expires_at = datetime.now(timezone.utc) + timedelta(
+            seconds=_MINERU_RAW_EXPIRES_SECONDS,
+        )
+        return {
+            "document_id": document.document_id,
+            "namespace": document.namespace,
+            "job_id": job.job_id,
+            "job_result_id": job_result.id,
+            "file_name": _MINERU_RAW_FILE_NAME,
+            "content_type": "application/zip",
+            "url": download_url,
             "expires_at": expires_at.isoformat(),
         }
 

--- a/apps/api/tests/contract/test_documents_contract.py
+++ b/apps/api/tests/contract/test_documents_contract.py
@@ -270,6 +270,11 @@ async def _insert_document_revision_with_chunks(
     section_id = f"sec_{uuid4().hex[:12]}"
     if mineru_raw_s3_key == "auto":
         mineru_raw_s3_key = f"results/{job_id}/mineru_raw.zip"
+    elif mineru_raw_s3_key == "sharded":
+        mineru_raw_s3_key = (
+            f"results/{job_id}/mineru_raw_shard0.zip\n"
+            f"results/{job_id}/mineru_raw_shard1.zip"
+        )
 
     try:
         async with engine.begin() as connection:
@@ -981,6 +986,48 @@ async def test_should_return_not_found_when_mineru_raw_key_is_missing(
         )
 
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_should_return_multiple_mineru_raw_urls_for_sharded_document(
+    developer_api_client_factory: Callable[
+        [], AbstractAsyncContextManager[AsyncClient]
+    ],
+) -> None:
+    document_id = f"doc_{uuid4().hex[:12]}"
+
+    async with developer_api_client_factory() as api_client:
+        revision = await _insert_document_revision_with_chunks(
+            document_id=document_id,
+            chunks=[
+                {
+                    "id": f"dchk_{uuid4().hex[:12]}",
+                    "chunk_id": "chunk-text",
+                    "chunk_type": "text",
+                    "content": "Chunk content",
+                    "source_chunk_path": "Chunk 1",
+                    "metadata": {"page_nums": []},
+                }
+            ],
+            mineru_raw_s3_key="sharded",
+        )
+        response = await api_client.get(
+            f"/api/v2/documents/{document_id}/files/mineru-raw"
+        )
+
+    assert response.status_code == 200
+
+    response_json = cast(dict[str, object], response.json())
+    assert response_json["job_id"] == revision["job_id"]
+    assert response_json["urls"] == [
+        "filesystem://knowhere-test-results/"
+        f"results/{revision['job_id']}/mineru_raw_shard0.zip"
+        "?method=GET&expires_in=604800",
+        "filesystem://knowhere-test-results/"
+        f"results/{revision['job_id']}/mineru_raw_shard1.zip"
+        "?method=GET&expires_in=604800",
+    ]
+    assert "url" not in response_json
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/contract/test_documents_contract.py
+++ b/apps/api/tests/contract/test_documents_contract.py
@@ -261,12 +261,15 @@ async def _insert_document_revision_with_chunks(
     source_file_name: str = "contract-chunks.pdf",
     parse_track: str = "chunk",
     status: str = "active",
+    mineru_raw_s3_key: str | None = None,
 ) -> dict[str, str]:
     engine = await _create_contract_engine()
     timestamp = datetime.now(timezone.utc).replace(tzinfo=None)
     job_id = str(uuid4())
     job_result_id = str(uuid4())
     section_id = f"sec_{uuid4().hex[:12]}"
+    if mineru_raw_s3_key == "auto":
+        mineru_raw_s3_key = f"results/{job_id}/mineru_raw.zip"
 
     try:
         async with engine.begin() as connection:
@@ -357,6 +360,7 @@ async def _insert_document_revision_with_chunks(
                         inline_payload,
                         result_s3_key,
                         result_size,
+                        mineru_raw_s3_key,
                         created_at,
                         updated_at
                     ) VALUES (
@@ -368,6 +372,7 @@ async def _insert_document_revision_with_chunks(
                         CAST('{}' AS JSON),
                         :result_s3_key,
                         0,
+                        :mineru_raw_s3_key,
                         :created_at,
                         :updated_at
                     )
@@ -377,6 +382,7 @@ async def _insert_document_revision_with_chunks(
                     "job_id": job_id,
                     "document_id": document_id,
                     "result_s3_key": f"results/{job_id}.zip",
+                    "mineru_raw_s3_key": mineru_raw_s3_key,
                     "created_at": timestamp,
                     "updated_at": timestamp,
                 },
@@ -883,6 +889,129 @@ async def test_should_return_not_found_for_other_users_page_citation_source(
         _upload_page_citation_source(job_id=revision["job_id"])
         response = await api_client.get(
             f"/api/v2/documents/{document_id}/files/page-citation-source"
+        )
+
+    assert response.status_code == 404
+
+
+def _upload_mineru_raw_zip(*, job_id: str) -> None:
+    from shared.services.storage.result_storage import JobResultStorage
+
+    raw_zip_path = Path("/tmp") / f"knowhere-contract-mineru-raw-{job_id}.zip"
+    raw_zip_path.write_bytes(b"PK\x03\x04contract mineru raw zip\n")
+    try:
+        JobResultStorage().upload_raw_file(
+            job_id=job_id,
+            relative_path="mineru_raw.zip",
+            local_file_path=str(raw_zip_path),
+        )
+    finally:
+        raw_zip_path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_should_return_mineru_raw_zip_for_document(
+    developer_api_client_factory: Callable[
+        [], AbstractAsyncContextManager[AsyncClient]
+    ],
+) -> None:
+    document_id = f"doc_{uuid4().hex[:12]}"
+
+    async with developer_api_client_factory() as api_client:
+        revision = await _insert_document_revision_with_chunks(
+            document_id=document_id,
+            chunks=[
+                {
+                    "id": f"dchk_{uuid4().hex[:12]}",
+                    "chunk_id": "chunk-text",
+                    "chunk_type": "text",
+                    "content": "Chunk content",
+                    "source_chunk_path": "Chunk 1",
+                    "metadata": {"page_nums": []},
+                }
+            ],
+            mineru_raw_s3_key="auto",
+        )
+        _upload_mineru_raw_zip(job_id=revision["job_id"])
+        response = await api_client.get(
+            f"/api/v2/documents/{document_id}/files/mineru-raw"
+        )
+
+    assert response.status_code == 200
+
+    response_json = cast(dict[str, object], response.json())
+    assert response_json["document_id"] == document_id
+    assert response_json["namespace"] == "contract-documents"
+    assert response_json["job_id"] == revision["job_id"]
+    assert response_json["job_result_id"] == revision["job_result_id"]
+    assert response_json["file_name"] == "mineru_raw.zip"
+    assert response_json["content_type"] == "application/zip"
+    assert response_json["url"] == (
+        "filesystem://knowhere-test-results/"
+        f"results/{revision['job_id']}/mineru_raw.zip"
+        "?method=GET&expires_in=604800"
+    )
+    assert response_json["expires_at"]
+
+
+@pytest.mark.asyncio
+async def test_should_return_not_found_when_mineru_raw_key_is_missing(
+    developer_api_client_factory: Callable[
+        [], AbstractAsyncContextManager[AsyncClient]
+    ],
+) -> None:
+    document_id = f"doc_{uuid4().hex[:12]}"
+
+    async with developer_api_client_factory() as api_client:
+        await _insert_document_revision_with_chunks(
+            document_id=document_id,
+            chunks=[
+                {
+                    "id": f"dchk_{uuid4().hex[:12]}",
+                    "chunk_id": "chunk-text",
+                    "chunk_type": "text",
+                    "content": "Chunk content",
+                    "source_chunk_path": "Chunk 1",
+                    "metadata": {"page_nums": []},
+                }
+            ],
+        )
+        response = await api_client.get(
+            f"/api/v2/documents/{document_id}/files/mineru-raw"
+        )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_should_return_not_found_for_other_users_mineru_raw_zip(
+    developer_api_client_factory: Callable[
+        [], AbstractAsyncContextManager[AsyncClient]
+    ],
+) -> None:
+    document_id = f"doc_{uuid4().hex[:12]}"
+    other_user_id = f"contract-user-{uuid4().hex[:12]}"
+
+    async with developer_api_client_factory() as api_client:
+        await ContractDatabase.insert_user(user_id=other_user_id)
+        revision = await _insert_document_revision_with_chunks(
+            document_id=document_id,
+            user_id=other_user_id,
+            chunks=[
+                {
+                    "id": f"dchk_{uuid4().hex[:12]}",
+                    "chunk_id": "chunk-text",
+                    "chunk_type": "text",
+                    "content": "Chunk content",
+                    "source_chunk_path": "Chunk 1",
+                    "metadata": {"page_nums": []},
+                }
+            ],
+            mineru_raw_s3_key="auto",
+        )
+        _upload_mineru_raw_zip(job_id=revision["job_id"])
+        response = await api_client.get(
+            f"/api/v2/documents/{document_id}/files/mineru-raw"
         )
 
     assert response.status_code == 404

--- a/apps/api/tests/migrations/test_schema_contract.py
+++ b/apps/api/tests/migrations/test_schema_contract.py
@@ -277,3 +277,22 @@ def test_agentic_retrieval_trace_schema_matches_orm(migrated_head_engine: Engine
         "workflow_step_id",
         "workflow_plan",
     }.issubset(run_columns)
+
+
+def test_job_results_mineru_raw_s3_key_column_exists(
+    migrated_head_engine: Engine,
+) -> None:
+    with migrated_head_engine.begin() as connection:
+        result = connection.execute(
+            text(
+                """
+                SELECT column_name, is_nullable
+                FROM information_schema.columns
+                WHERE table_name = 'job_results'
+                  AND column_name = 'mineru_raw_s3_key'
+                """
+            )
+        ).mappings().first()
+
+    assert result is not None
+    assert result["is_nullable"] == "YES"

--- a/apps/worker/app/services/document_ingestion/success_finalization.py
+++ b/apps/worker/app/services/document_ingestion/success_finalization.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Optional
 
 from app.services.connect_builder.summary_builder import (
     build_section_summary_lookup,
@@ -81,6 +81,9 @@ def finalize_parse_success(
         result_storage_factory=result_storage_factory,
     )
     stored_count = 0
+    mineru_raw_s3_key = _read_mineru_raw_s3_key_sidecar(
+        result_package=result_package,
+    )
 
     finalization_response = lifecycle_service.finalize_job_success(
         job_id=job_id,
@@ -92,6 +95,7 @@ def finalize_parse_success(
         delivery_mode="url",
         section_summaries=section_summaries,
         document_top_summary=document_top_summary,
+        mineru_raw_s3_key=mineru_raw_s3_key,
     )
     if finalization_response.get("status") != "success":
         logger.error(
@@ -258,3 +262,35 @@ def _upload_result_package(
         artifact_refs=artifact_refs,
     )
     return result_bundle.zip_key
+
+
+_MINERU_RAW_SIDECAR_FILE_NAME = "_mineru_raw_s3_key.txt"
+
+
+def _read_mineru_raw_s3_key_sidecar(
+    *,
+    result_package: ParseResultPackage,
+) -> Optional[str]:
+    """Read the raw MinerU ZIP S3 key written by the parser, if any.
+
+    The parser (local or cloud mode) writes ``_mineru_raw_s3_key.txt`` into
+    its output directory, which surfaces here as ``artifact.add_dir``.
+    Returns ``None`` when the raw ZIP was not archived (e.g. inline JSON
+    fallback response, or a non-MinerU parse track).
+    """
+    add_dir = result_package.artifact.add_dir
+    if not add_dir:
+        return None
+    sidecar_path = os.path.join(str(add_dir), _MINERU_RAW_SIDECAR_FILE_NAME)
+    if not os.path.isfile(sidecar_path):
+        return None
+    try:
+        with open(sidecar_path, "r", encoding="utf-8") as sidecar_file:
+            sidecar_value = sidecar_file.read().strip()
+    except OSError as exc:
+        logger.warning(f"Failed to read MinerU raw sidecar {sidecar_path}: {exc}")
+        return None
+    if not sidecar_value:
+        return None
+    logger.info(f"Attaching MinerU raw ZIP key to job result: {sidecar_value}")
+    return sidecar_value

--- a/apps/worker/app/services/document_parser/formats/markdown/image_asset.py
+++ b/apps/worker/app/services/document_parser/formats/markdown/image_asset.py
@@ -135,6 +135,7 @@ def build_markdown_image_asset(
 def build_markdown_image_name(*, image_count: int, last_context: str) -> str:
     image_name_context = path_handle(last_context.strip(), mode="clean_single")
     if image_name_context:
+        image_name_context = image_name_context[:60]
         return f"image-{image_count}-{image_name_context}"
     return f"image-{image_count}"
 

--- a/packages/shared-python/shared/models/database/job_result.py
+++ b/packages/shared-python/shared/models/database/job_result.py
@@ -43,6 +43,7 @@ class JobResult(Base):
     )
     result_s3_key: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
     result_size: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    mineru_raw_s3_key: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=utc_now_naive, nullable=False

--- a/packages/shared-python/shared/services/jobs/lifecycle/result_writer.py
+++ b/packages/shared-python/shared/services/jobs/lifecycle/result_writer.py
@@ -21,6 +21,7 @@ class SyncJobResultWriter:
         inline_payload: dict[str, Any] | None = None,
         result_s3_key: str | None = None,
         result_size: int | None = None,
+        mineru_raw_s3_key: str | None = None,
     ) -> JobResult:
         result = db.execute(select(JobResult).where(JobResult.job_id == job_id))
         existing = result.scalar_one_or_none()
@@ -30,6 +31,7 @@ class SyncJobResultWriter:
             existing.inline_payload = inline_payload
             existing.result_s3_key = result_s3_key
             existing.result_size = result_size
+            existing.mineru_raw_s3_key = mineru_raw_s3_key
             db.flush()
             return existing
 
@@ -40,6 +42,7 @@ class SyncJobResultWriter:
             inline_payload=inline_payload,
             result_s3_key=result_s3_key,
             result_size=result_size,
+            mineru_raw_s3_key=mineru_raw_s3_key,
         )
         db.add(job_result)
         db.flush()

--- a/packages/shared-python/shared/services/jobs/lifecycle/service.py
+++ b/packages/shared-python/shared/services/jobs/lifecycle/service.py
@@ -53,6 +53,7 @@ class SyncJobLifecycleService:
         delivery_mode: str = "url",
         section_summaries: Optional[Dict[str, str]] = None,
         document_top_summary: Optional[str] = None,
+        mineru_raw_s3_key: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Finalize a successful job in a single atomic transaction.
 
@@ -80,6 +81,7 @@ class SyncJobLifecycleService:
                 delivery_mode=delivery_mode,
                 section_summaries=section_summaries,
                 document_top_summary=document_top_summary,
+                mineru_raw_s3_key=mineru_raw_s3_key,
             ),
             should_commit=lambda finalization: finalization.response.should_commit(),
             build_response=lambda finalization: finalization.response.to_dict(),

--- a/packages/shared-python/shared/services/jobs/lifecycle/success_finalizer.py
+++ b/packages/shared-python/shared/services/jobs/lifecycle/success_finalizer.py
@@ -80,6 +80,7 @@ class SyncJobSuccessFinalizer:
         delivery_mode: str,
         section_summaries: dict[str, str] | None,
         document_top_summary: str | None = None,
+        mineru_raw_s3_key: str | None = None,
     ) -> JobSuccessFinalization:
         job_result = self._result_writer.upsert_job_result(
             db,
@@ -88,6 +89,7 @@ class SyncJobSuccessFinalizer:
             inline_payload={"checksum": checksum},
             result_s3_key=result_s3_key,
             result_size=zip_size,
+            mineru_raw_s3_key=mineru_raw_s3_key,
         )
         self._result_writer.replace_chunks(db, job_result.id, chunks)
         publication_outcome = self._publication_finalizer.publish_result(

--- a/packages/shared-python/shared/services/storage/result_storage.py
+++ b/packages/shared-python/shared/services/storage/result_storage.py
@@ -45,6 +45,11 @@ class ResultStorage(Protocol):
     ) -> str | None:
         raise NotImplementedError
 
+    def generate_url(
+        self, *, storage_key: str, expires_in: int = 3600
+    ) -> str | None:
+        raise NotImplementedError
+
     def verify_raw_exists(self, *, job_id: str, relative_path: str) -> bool:
         raise NotImplementedError
 


### PR DESCRIPTION
## What

Completes the MinerU raw ZIP audit archive (ADR 0002, steps 1/6, 2/6, 5/6, 6/6): persist the archived raw ZIP's S3 key on `job_results` and expose it via a download endpoint.

> **Stacked note:** this branch is based on `main` + the two commits in this PR. Steps 3/6 (local mode, PR #233) and 4/6 (cloud mode, PR #238) write the `_mineru_raw_s3_key.txt` sidecar this PR reads; the reader is defensive (returns None when absent), so this PR is mergeable independently — the feature only lights up end-to-end once 3/6/4/6 land.

## Changes

### DB (steps 1/6 + 2/6)

- Alembic migration `fce1c2d3e4f6`: nullable `mineru_raw_s3_key TEXT` column on `job_results` (matches the existing `result_s3_key` pattern)
- `JobResult` ORM field
- Schema contract test asserting the column exists and is nullable

### Caller wiring (step 5/6)

- `finalize_parse_success` reads `_mineru_raw_s3_key.txt` from the parse output dir (`artifact.add_dir`) and passes the value through `finalize_job_success`
- `mineru_raw_s3_key` threaded through `SyncJobLifecycleService` → `SyncJobSuccessFinalizer` → `SyncJobResultWriter.upsert_job_result`
- `ResultStorage` protocol gains `generate_url(storage_key, ...)` (already implemented by `JobResultStorage`)

### Download API (step 6/6)

`GET /api/v2/documents/{document_id}/files/mineru-raw` — mirrors the `page-citation-source` endpoint pattern:
- Looks up document → current job result → `mineru_raw_s3_key`
- Returns `404` when the document is not found or no raw key is stored
- Otherwise returns `{document_id, namespace, job_id, job_result_id, file_name, content_type, url, expires_at}` with a 7-day presigned URL

Contract tests: happy path (asserts presigned URL shape), missing key → 404, other-user isolation → 404.

## Tests

- `apps/api/tests/migrations` — 6 passed (incl. new column contract test)
- `apps/api/tests/contract/test_documents_contract.py` — 26 passed (incl. 3 new mineru-raw tests)
- `apps/api/tests/contract/test_demo_documents_contract.py` — 8 passed
- `apps/worker/tests/contract/test_parse_task_contract.py` + `test_webhook_recovery_contract.py` — 18 passed
- ruff + pyright clean
