### PR TITLE
Fix ECS worker ephemeral storage minimum

### DIFF
--- a/deploy/ecs/task-definition-worker.staging.json
+++ b/deploy/ecs/task-definition-worker.staging.json
@@ -6,7 +6,7 @@
   "requiresCompatibilities": ["FARGATE"],
   "cpu": "512",
   "memory": "4096",
-  "ephemeralStorage": {"sizeInGiB": 20},
+  "ephemeralStorage": {"sizeInGiB": 21},
   "runtimePlatform": {
     "cpuArchitecture": "X86_64",
     "operatingSystemFamily": "LINUX"


### PR DESCRIPTION
## Summary

- change the staging worker task-definition ephemeral storage from 20 GiB to 21 GiB because the ECS API rejects values below 21 GiB

Part of Ontos-AI/knowhere-api-infra#22 and #19.

## Verification

- `uv run pytest deploy/ecs/test_render_task_definitions.py -q` (6 passed)
- registered staging worker task definition `knowhere-worker-staging:1` successfully with 21 GiB

No service was started or updated.