### PR TITLE
Fix staging Neon migration configuration

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -282,6 +282,9 @@ jobs:
         shell: bash
         env:
           DATABASE_URL: ${{ secrets.STAGING_MIGRATION_DATABASE_URL }}
+          S3_BUCKET_NAME: knowhere-storage-staging
+          S3_TEMP_PATH: /tmp
+          TMP_PATH: /tmp/aismart_bid
         run: |
           set -euo pipefail
           short_sha="${GITHUB_SHA::8}"


### PR DESCRIPTION
## Summary

- provide the existing staging S3 bucket and temporary paths to the Alembic migration container
- keep the direct Neon migration URL in the repository secret

The previous staging run reached Alembic but failed before connecting because AppConfig requires these non-secret settings. No AWS resources or deployment behavior are changed by this PR.