### PR TITLE
Fix staging migration container environment

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -291,6 +291,9 @@ jobs:
           image_uri="${ECR_REGISTRY}/${ECR_REPOSITORY}/knowhere-backend:staging-${short_sha}"
           docker run --rm \
             --env DATABASE_URL \
+            --env S3_BUCKET_NAME \
+            --env S3_TEMP_PATH \
+            --env TMP_PATH \
             --env DB_SSL_MODE=require \
             --entrypoint python \
             "$image_uri" \


### PR DESCRIPTION
## Summary

- explicitly pass the staging S3 and temporary-path variables into the Docker migration container

The previous workflow exposed these values to the GitHub runner but did not pass them through docker run, so AppConfig still failed before Alembic connected. No AWS resources or deployment behavior are changed by this PR.