### PR TITLE
Fix ECS log group prerequisite lookup

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -480,7 +480,7 @@ jobs:
 
           for log_group in /ecs/knowhere-api-staging /ecs/knowhere-worker-staging; do
             found="$(aws logs describe-log-groups \
-              --log-group-name "$log_group" \
+              --log-group-name-prefix "$log_group" \
               --query 'logGroups[0].logGroupName' --output text)"
             if [ "$found" != "$log_group" ]; then
               echo "::error::Required CloudWatch log group ${log_group} does not exist."


### PR DESCRIPTION
## Summary

- use the AWS CLI-supported `--log-group-name-prefix` option in the ECS staging prerequisite check
- preserve exact returned log-group-name validation

The previous deployment stopped before any ECS update because the installed AWS CLI rejects `--log-group-name` as ambiguous. This changes only the workflow check and does not alter AWS resources or service counts.