### PR TITLE
fix: avoid gevent signal shutdown error

### DIFF
--- a/apps/worker/tests/contract/test_worker_shutdown_contract.py
+++ b/apps/worker/tests/contract/test_worker_shutdown_contract.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 
-def test_should_preserve_fargate_worker_soft_shutdown_contract(
+def test_should_preserve_fargate_worker_sigterm_shutdown_contract(
     worker_contract_environment: None,
 ) -> None:
     from shared.core.celery_app import celery_app
@@ -31,5 +31,5 @@ def test_should_preserve_fargate_worker_soft_shutdown_contract(
 
     assert celery_app.conf.worker_soft_shutdown_timeout == 90
     assert celery_app.conf.worker_enable_soft_shutdown_on_idle is True
-    assert environment_values["REMAP_SIGTERM"] == "SIGQUIT"
+    assert "REMAP_SIGTERM" not in environment_values
     assert worker_container["stopTimeout"] == 120

--- a/deploy/ecs/task-definition-worker.staging.json
+++ b/deploy/ecs/task-definition-worker.staging.json
@@ -20,7 +20,6 @@
       "environment": [
         {"name": "ENVIRONMENT", "value": "staging"},
         {"name": "APP_ENV", "value": "staging"},
-        {"name": "REMAP_SIGTERM", "value": "SIGQUIT"},
         {"name": "DB_SSL_MODE", "value": "require"},
         {"name": "DB_SYNC_POOL_SIZE", "value": "2"},
         {"name": "DB_SYNC_MAX_OVERFLOW", "value": "2"},


### PR DESCRIPTION
## Summary
- remove `REMAP_SIGTERM=SIGQUIT` from the staging worker task definition
- keep ECS `stopTimeout=120` and Celery soft-shutdown settings
- update the worker shutdown contract to require the normal SIGTERM path

## Root cause
ECS sends SIGTERM. The remap routed it into Celery 5.5.3's cold-shutdown handler, which calls its soft-shutdown sleep from a gevent signal/event-loop callback. The staging drill reproduced `gevent.exceptions.BlockingSwitchOutError`.

The normal SIGTERM warm-shutdown path avoids that incompatible callback while retaining late acknowledgements and ECS task replacement behavior.

## Verification
- `uv run --directory /home/suguan/github.com/ontosAI/knowhere pytest -q apps/worker/tests/contract/test_worker_shutdown_contract.py apps/worker/tests/contract/test_worker_bootstrap_contract.py`
- Result: `3 passed`

Staging deployment and interruption re-test are intentionally deferred until this PR is reviewed and merged.
