### PR TITLE
perf(ecs): increase staging worker CPU

### DIFF
--- a/deploy/ecs/task-definition-worker.staging.json
+++ b/deploy/ecs/task-definition-worker.staging.json
@@ -4,7 +4,7 @@
   "executionRoleArn": "${EXECUTION_ROLE_ARN}",
   "networkMode": "awsvpc",
   "requiresCompatibilities": ["FARGATE"],
-  "cpu": "512",
+  "cpu": "1024",
   "memory": "4096",
   "ephemeralStorage": {"sizeInGiB": 21},
   "runtimePlatform": {

--- a/deploy/ecs/test_render_task_definitions.py
+++ b/deploy/ecs/test_render_task_definitions.py
@@ -119,6 +119,17 @@ def test_staging_templates_preserve_expected_staging_configuration(
         assert environment_values[name] == value
 
 
+def test_staging_worker_preserves_evidence_selected_capacity() -> None:
+    """Worker capacity matches the staging load evidence recorded in issue 22."""
+    definition_path: Path = TEMPLATE_DIRECTORY / "task-definition-worker.staging.json"
+    definition: dict[str, object] = json.loads(
+        definition_path.read_text(encoding="utf-8")
+    )
+
+    assert definition["cpu"] == "1024"
+    assert definition["memory"] == "4096"
+
+
 def test_renderer_rejects_forbidden_s3_credential_variable() -> None:
     """Task definitions must never inject long-lived S3 credentials."""
     definition: dict[str, object] = {


### PR DESCRIPTION
## Summary

- Increase the staging worker task from 512 CPU units to 1024 CPU units based on the measured 2 jobs/minute load-test evidence.
- Retain 4096 MiB memory and `WORKER_CONCURRENCY=10`.
- Add a rendering contract that protects the evidence-selected staging CPU and memory settings.
- No production task definition, workflow, environment variable, migration, queue, storage, or application behavior changes are included.
- Related infrastructure plan: Ontos-AI/knowhere-api-infra#22

## Verification

- `uv run --group lint ruff check deploy/ecs/test_render_task_definitions.py deploy/ecs/render_task_definitions.py`
- `uv run pytest deploy/ecs/test_render_task_definitions.py apps/worker/tests/contract/test_worker_shutdown_contract.py -q` — 10 passed
- Rendered the staging worker artifact and verified CPU 1024, memory 4096, and concurrency 10.
- `git diff --check`
- `uv run pytest -q` — 473 passed, 4 unrelated failures, 14 warnings. Two summary-builder tests attempted the external `https://example.com/v1/chat/completions` endpoint; two page-memory tests use stale mocks that reject `api_key` and `api_url`. These failures are outside this two-file capacity change.

## Deployment Notes

- This PR targets `main` only and does not deploy the change.
- No environment variables, database migrations, queue changes, or storage changes.
- Staging promotion and deployment require separate approval after merge.
- The staging service remains unchanged by this PR creation; rollback is the prior 512-CPU task definition revision.

## Checklist

- [x] Tests were added or updated when behavior changed
- [x] Public docs, examples, or OpenAPI contracts were updated when needed — not applicable
- [x] Database migrations are idempotent and safe to deploy — not applicable
- [x] Logs, errors, and validation paths avoid leaking secrets or user data
- [x] The pull request description explains any breaking or user-visible change — no breaking or user-visible change