### PR TITLE
fix(ecs): preserve validated staging worker CPU

### DIFF
--- a/deploy/ecs/task-definition-worker.staging.json
+++ b/deploy/ecs/task-definition-worker.staging.json
@@ -4,7 +4,7 @@
   "executionRoleArn": "${EXECUTION_ROLE_ARN}",
   "networkMode": "awsvpc",
   "requiresCompatibilities": ["FARGATE"],
-  "cpu": "1024",
+  "cpu": "2048",
   "memory": "4096",
   "ephemeralStorage": {"sizeInGiB": 21},
   "runtimePlatform": {

--- a/deploy/ecs/test_render_task_definitions.py
+++ b/deploy/ecs/test_render_task_definitions.py
@@ -126,7 +126,9 @@ def test_staging_worker_preserves_evidence_selected_capacity() -> None:
         definition_path.read_text(encoding="utf-8")
     )
 
-    assert definition["cpu"] == "1024"
+    # The measured production-envelope replay rejected 1-vCPU tasks and passed
+    # on two fixed 2-vCPU tasks, so CD must not restore the rejected task size.
+    assert definition["cpu"] == "2048"
     assert definition["memory"] == "4096"
 
 


### PR DESCRIPTION
## Summary

- change the staging worker ECS task size from 1 vCPU to the evidence-selected 2 vCPU while retaining 4 GiB memory and `WORKER_CONCURRENCY=10`
- update the ECS deployment contract so CI cannot restore the rejected 1-vCPU task size

## Evidence

The one-vCPU staging topology failed the worker health gate under the measured production envelope. Two fixed 2-vCPU/4-GiB Fargate Spot tasks passed the accepted envelope through the final 100-jobs/60-minute window.

Evidence: https://github.com/Ontos-AI/knowhere-api-infra/issues/22#issuecomment-5302077433

## Verification

- `uv run pytest deploy/ecs/test_render_task_definitions.py -q` — 7 passed
- `uv run --group lint ruff check deploy/ecs/test_render_task_definitions.py deploy/ecs/render_task_definitions.py` — passed
- `git diff --check` — passed

A repository-wide `uv run pytest -q` was also attempted, but collection requires optional workspace dependencies and runtime configuration absent from the isolated worktree (`shared`, `fakeredis`, `fitz`, `syntok`, and S3/database settings). The complete ECS deployment contract suite passes.

## Deployment

This PR changes only the deployment source and its contract. It does not update an ECS service or create/remove any AWS resource.
