### PR TITLE
fix(ecs): preserve validated staging worker CPU

### DIFF
--- a/deploy/ecs/task-definition-worker.staging.json
+++ b/deploy/ecs/task-definition-worker.staging.json
@@ -4,7 +4,7 @@
   "executionRoleArn": "${EXECUTION_ROLE_ARN}",
   "networkMode": "awsvpc",
   "requiresCompatibilities": ["FARGATE"],
-  "cpu": "1024",
+  "cpu": "2048",
   "memory": "4096",
   "ephemeralStorage": {"sizeInGiB": 21},
   "runtimePlatform": {

--- a/deploy/ecs/test_render_task_definitions.py
+++ b/deploy/ecs/test_render_task_definitions.py
@@ -126,7 +126,9 @@ def test_staging_worker_preserves_evidence_selected_capacity() -> None:
         definition_path.read_text(encoding="utf-8")
     )
 
-    assert definition["cpu"] == "1024"
+    # The measured production-envelope replay rejected 1-vCPU tasks and passed
+    # on two fixed 2-vCPU tasks, so CD must not restore the rejected task size.
+    assert definition["cpu"] == "2048"
     assert definition["memory"] == "4096"
 
 


### PR DESCRIPTION
## Summary

- cherry-pick the reviewed main-branch change that sets the staging worker ECS task size to 2 vCPU / 4 GiB
- preserve explicit `WORKER_CONCURRENCY=10`
- update the ECS deployment contract so the staging CD source matches validated revision 12

## Evidence

The one-vCPU topology is rejected by the measured worker health evidence. Two fixed 2-vCPU/4-GiB Fargate Spot tasks passed the accepted production-envelope replay through 100 jobs / 60 minutes.

Evidence: https://github.com/Ontos-AI/knowhere-api-infra/issues/22#issuecomment-5302077433

Main-branch source commit: `9937fc53`
Staging cherry-pick: `6e81538f`

## Verification

- `uv run pytest deploy/ecs/test_render_task_definitions.py -q` — 7 passed
- `uv run --group lint ruff check deploy/ecs/test_render_task_definitions.py deploy/ecs/render_task_definitions.py` — passed
- `git diff --check` — passed
- branch diff is identical to the reviewed main-branch diff

A repository-wide `uv run pytest -q` was attempted on the main branch, but collection requires optional workspace dependencies and runtime configuration absent from the isolated worktree. The complete ECS deployment contract suite passes on both branches.

## Deployment note

Creating this PR does not deploy. Merging it into `staging` will trigger the existing staging CD workflow, register a new task-definition revision at 2 vCPU / 4 GiB, preserve the service's current desired count, and roll the staging worker tasks.
