### PR TITLE
Wait for worker health before staging API startup

### DIFF
--- a/.github/workflows/manage-staging.yml
+++ b/.github/workflows/manage-staging.yml
@@ -112,6 +112,47 @@ jobs:
               --services "$service_name"
           }
 
+          wait_for_healthy_workers() {
+            local worker_health_deadline="$((SECONDS + 300))"
+            local healthy_worker_count="0"
+            local -a worker_tasks=()
+
+            # The AWS CLI services-stable waiter checks deployment count and
+            # runningCount only. A cold task can therefore be RUNNING while
+            # container health remains UNKNOWN during its health-check
+            # startPeriod. Poll the task health explicitly before opening API
+            # admission, with a bounded timeout so a bad rollout still fails.
+            while (( SECONDS < worker_health_deadline )); do
+              healthy_worker_count="0"
+              worker_tasks=()
+              mapfile -t worker_tasks < <(
+                aws --profile knowhere ecs list-tasks \
+                  --cluster knowhere-fargate \
+                  --service-name knowhere-worker-staging \
+                  --desired-status RUNNING \
+                  --query 'taskArns[]' \
+                  --output text | tr '\t' '\n' | sed '/^None$/d;/^$/d'
+              )
+
+              if [ "${#worker_tasks[@]}" -eq 2 ]; then
+                healthy_worker_count="$(aws --profile knowhere ecs describe-tasks \
+                  --cluster knowhere-fargate \
+                  --tasks "${worker_tasks[@]}" \
+                  --query 'length(tasks[?lastStatus==`RUNNING` && healthStatus==`HEALTHY`])' \
+                  --output text)"
+                if [ "$healthy_worker_count" -eq 2 ]; then
+                  return 0
+                fi
+              fi
+
+              echo "Waiting for two healthy worker tasks; running=${#worker_tasks[@]}, healthy=$healthy_worker_count"
+              sleep 15
+            done
+
+            echo "Timed out waiting for two healthy worker tasks" >&2
+            return 1
+          }
+
           read_services() {
             aws --profile knowhere ecs describe-services \
               --cluster knowhere-fargate \
@@ -129,27 +170,7 @@ jobs:
               # traffic; ECS stability alone does not prove container health.
               update_service knowhere-worker-staging 2
               wait_for_service knowhere-worker-staging
-              mapfile -t worker_tasks < <(
-                aws --profile knowhere ecs list-tasks \
-                  --cluster knowhere-fargate \
-                  --service-name knowhere-worker-staging \
-                  --desired-status RUNNING \
-                  --query 'taskArns[]' \
-                  --output text | tr '\t' '\n'
-              )
-              if [ "${#worker_tasks[@]}" -ne 2 ]; then
-                echo "Expected two running worker tasks, found ${#worker_tasks[@]}" >&2
-                exit 1
-              fi
-              healthy_workers="$(aws --profile knowhere ecs describe-tasks \
-                --cluster knowhere-fargate \
-                --tasks "${worker_tasks[@]}" \
-                --query 'length(tasks[?lastStatus==`RUNNING` && healthStatus==`HEALTHY`])' \
-                --output text)"
-              if [ "$healthy_workers" -ne 2 ]; then
-                echo "Expected two healthy workers, found $healthy_workers" >&2
-                exit 1
-              fi
+              wait_for_healthy_workers
 
               update_service knowhere-api-staging 1
               wait_for_service knowhere-api-staging

--- a/deploy/ecs/test_manage_staging_workflow.py
+++ b/deploy/ecs/test_manage_staging_workflow.py
@@ -54,14 +54,29 @@ def test_start_restores_healthy_workers_before_api() -> None:
         start_block.index("wait_for_service knowhere-worker-staging")
     )
     assert start_block.index("wait_for_service knowhere-worker-staging") < (
-        start_block.index('if [ "$healthy_workers" -ne 2 ]')
+        start_block.index("wait_for_healthy_workers")
     )
-    assert start_block.index('if [ "$healthy_workers" -ne 2 ]') < (
+    assert start_block.index("wait_for_healthy_workers") < (
         start_block.index("update_service knowhere-api-staging 1")
     )
     assert start_block.index("update_service knowhere-api-staging 1") < (
         start_block.index("https://api-staging.knowhereto.ai/health")
     )
+
+
+def test_worker_health_gate_polls_through_container_start_period() -> None:
+    """A newly running worker may remain health-unknown during startPeriod."""
+    workflow: str = _read_workflow()
+    health_gate: str = workflow.split(
+        "          wait_for_healthy_workers() {", maxsplit=1
+    )[1].split("\n          }", maxsplit=1)[0]
+
+    assert 'worker_health_deadline="$((SECONDS + 300))"' in health_gate
+    assert "while (( SECONDS < worker_health_deadline )); do" in health_gate
+    assert "healthStatus==`HEALTHY`" in health_gate
+    assert 'if [ "$healthy_worker_count" -eq 2 ]; then' in health_gate
+    assert "sleep 15" in health_gate
+    assert 'echo "Timed out waiting for two healthy worker tasks"' in health_gate
 
 
 def test_stop_closes_api_then_drains_before_workers() -> None:


### PR DESCRIPTION
## Summary

- replace the staging start workflow's one-shot worker health assertion with a bounded polling gate
- wait for exactly two `RUNNING` and `HEALTHY` worker tasks before opening API admission
- retain a five-minute failure bound and keep the API stopped when worker health never converges
- add a contract for the cold-start health-check `startPeriod` regression

## Evidence

The first manual cold-start run failed safely: [run 31894301138](https://github.com/Ontos-AI/knowhere/actions/runs/31894301138). Both revision-14 tasks entered `RUNNING` around `00:01:20 Asia/Shanghai`, while the workflow checked health around `00:01:33` and found zero healthy tasks. The task definition has a 60-second container health-check `startPeriod`; both tasks subsequently became `HEALTHY`. The API remained at desired count `0`.

The AWS CLI [`services-stable` waiter](https://docs.aws.amazon.com/cli/latest/reference/ecs/wait/services-stable.html) checks deployment count and `runningCount == desiredCount`; it does not wait for container health. We therefore poll task health explicitly every 15 seconds after the service waiter completes.

This is the bounded cold-start correction for Ontos-AI/knowhere-api-infra#30. It does not create resources or dispatch another AWS operation.

## Verification

- `uv run pytest deploy/ecs -q` — 15 passed
- `uv run --group lint ruff check deploy/ecs/test_manage_staging_workflow.py deploy/ecs/render_task_definitions.py deploy/ecs/test_render_task_definitions.py`
- `uv run --group typecheck pyright deploy/ecs/test_manage_staging_workflow.py`
- workflow YAML parsing and embedded Bash syntax check
- `git diff --check`
- standards review: no findings
- spec review: no findings