### PR TITLE
fix: set production environment for Aurora migration

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -362,6 +362,9 @@ jobs:
       - name: Run migration against production Aurora
         env:
           DATABASE_URL: ${{ secrets.PRODUCTION_MIGRATION_DATABASE_URL }}
+          # The image build metadata uses the short release label `prod`, but
+          # AppConfig validates the runtime environment as `production`.
+          ENVIRONMENT: production
           S3_BUCKET_NAME: knowhere-storage-prod
           S3_TEMP_PATH: /tmp
           TMP_PATH: /tmp/aismart_bid
@@ -375,6 +378,7 @@ jobs:
             --env TMP_PATH \
             --env S3_TEMP_PATH \
             --env DB_SSL_MODE=disable \
+            --env ENVIRONMENT \
             --entrypoint python \
             "${image_uri}" \
             -m alembic upgrade heads


### PR DESCRIPTION
## Summary
- pass `ENVIRONMENT=production` to the production Aurora migration container
- keep the image build metadata label `prod` separate from the runtime environment accepted by AppConfig

## Evidence
Release `v1.0.23` migration failed before Alembic ran because the image defaulted to `ENVIRONMENT=prod`.

## Validation
- workflow YAML parsed successfully
- `git diff --check` passed