### PR TITLE
Fix CodeQL comments from PR 305

### DIFF
--- a/apps/worker/scripts/debug_parse.py
+++ b/apps/worker/scripts/debug_parse.py
@@ -290,7 +290,7 @@ def _finalize_output(
         logger.info("  📊 POST-PARSE TIMELINE")
         logger.info("═" * 58)
         for phase, elapsed in timings.items():
-            pct = (elapsed / t_total * 100) if t_total > 0 else 0
+            pct = elapsed / t_total * 100
             logger.info(f"  {phase:<35s} │ {elapsed:>7.2f}s  ({pct:>5.1f}%)")
         logger.info("  " + "─" * 55)
         logger.info(f"  {'TOTAL':<35s} │ {t_total:>7.2f}s  (100.0%)")
@@ -487,15 +487,13 @@ def run_pipeline(
         init_token_tracker,
     )
 
-    token_usage_dict = get_current_token_tracker()
-    owns_token_tracker = token_usage_dict is None
-    if token_usage_dict is None:
-        token_usage_dict = init_token_tracker()
+    owns_token_tracker = get_current_token_tracker() is None
+    if owns_token_tracker:
+        init_token_tracker()
 
-    stage_timing_dict = get_current_stage_tracker()
-    owns_stage_tracker = stage_timing_dict is None
-    if stage_timing_dict is None:
-        stage_timing_dict = init_stage_tracker()
+    owns_stage_tracker = get_current_stage_tracker() is None
+    if owns_stage_tracker:
+        init_stage_tracker()
 
     try:
         if output_root_override:

--- a/apps/worker/scripts/debug_retrieval.py
+++ b/apps/worker/scripts/debug_retrieval.py
@@ -1100,7 +1100,6 @@ def _render_md_report(all_reports: list[dict[str, Any]]) -> str:
 
 
 async def main() -> None:
-    import re
     from datetime import datetime
 
     # Enable verbose logging to see full LLM prompts and responses

--- a/apps/worker/scripts/page_memory/_debug_pm_shared.py
+++ b/apps/worker/scripts/page_memory/_debug_pm_shared.py
@@ -55,6 +55,17 @@ from shared.services.ai.token_tracking import (
 )
 from shared.services.ai.token_costing import build_token_cost_estimate
 
+# Re-exported for staged debug scripts. Listing them here marks the imports as
+# intentional so CodeQL does not treat them as unused.
+__all__ = [
+    "page_scope_info",
+    "scope_id_for_pages",
+    "_build_hierarchy_from_skeletons",
+    "_derive_hierarchy_page_scope",
+    "_scope_manifest",
+    "_serialize_scope_skeletons",
+]
+
 DEFAULT_PDF = Path(
     "/Users/wuchengke/Desktop/temp/test_docs/"
     "SJSYJ-SC-2024 企业制度汇编（上册）.pdf"
@@ -866,11 +877,7 @@ def write_toc_hierarchy_artifact(
     path = out_dir / "toc_hierarchy.json"
     # Legacy list dump from an earlier debug format.
     for legacy_name in ("toc_hierarchies.json",):
-        legacy = out_dir / legacy_name
-        try:
-            legacy.unlink()
-        except FileNotFoundError:
-            pass
+        (out_dir / legacy_name).unlink(missing_ok=True)
     write_debug_json(
         path,
         {
@@ -1046,19 +1053,13 @@ def remove_legacy_doc_agent_artifacts(
             }
         )
     for name in names:
-        try:
-            (doc_agent_dir / name).unlink()
-        except FileNotFoundError:
-            pass
+        (doc_agent_dir / name).unlink(missing_ok=True)
     legacy_preview_dir = doc_agent_dir / "coarse_assets"
     if legacy_preview_dir.is_dir():
         import shutil
 
         shutil.rmtree(legacy_preview_dir)
-    try:
-        (doc_agent_dir / "coarse_assets.html").unlink()
-    except FileNotFoundError:
-        pass
+    (doc_agent_dir / "coarse_assets.html").unlink(missing_ok=True)
 
 
 def record_stage(
@@ -1399,9 +1400,7 @@ def stop_with_trace(
 
 def remove_nested_doc_agent_trace(out_dir: Path) -> None:
     try:
-        (out_dir / "_doc_agent" / "trace.json").unlink()
-    except FileNotFoundError:
-        pass
+        (out_dir / "_doc_agent" / "trace.json").unlink(missing_ok=True)
     except Exception as exc:
         logger.debug(f"failed to remove nested doc-agent trace: {exc}")
 
@@ -1452,10 +1451,7 @@ def write_top_level_artifacts(
     if assets_by_page is not None:
         write_debug_json(out_dir / "assets.json", _serialize_assets(assets_by_page))
     else:
-        try:
-            (out_dir / "assets.json").unlink()
-        except FileNotFoundError:
-            pass
+        (out_dir / "assets.json").unlink(missing_ok=True)
 
 
 def cleanup_page_memory_artifacts(out_dir: Path) -> None:

--- a/apps/worker/scripts/page_memory/debug_pm_stage0_bootstrap.py
+++ b/apps/worker/scripts/page_memory/debug_pm_stage0_bootstrap.py
@@ -19,7 +19,6 @@ from pathlib import Path as _Path
 
 sys.path.insert(0, str(_Path(__file__).resolve().parent))
 
-from _debug_pm_shared import *  # noqa: F401,F403
 import time
 
 from loguru import logger

--- a/apps/worker/scripts/page_memory/debug_pm_stage1_hierarchy.py
+++ b/apps/worker/scripts/page_memory/debug_pm_stage1_hierarchy.py
@@ -23,7 +23,6 @@ from pathlib import Path as _Path
 
 sys.path.insert(0, str(_Path(__file__).resolve().parent))
 
-from _debug_pm_shared import *  # noqa: F401,F403
 import time
 
 from loguru import logger

--- a/apps/worker/scripts/page_memory/debug_pm_stage2_calibration.py
+++ b/apps/worker/scripts/page_memory/debug_pm_stage2_calibration.py
@@ -26,7 +26,6 @@ from pathlib import Path as _Path
 
 sys.path.insert(0, str(_Path(__file__).resolve().parent))
 
-from _debug_pm_shared import *  # noqa: F401,F403
 from loguru import logger
 
 from _debug_pm_shared import (

--- a/apps/worker/scripts/page_memory/debug_pm_stage3_coarse_scope.py
+++ b/apps/worker/scripts/page_memory/debug_pm_stage3_coarse_scope.py
@@ -20,7 +20,6 @@ from pathlib import Path as _Path
 
 sys.path.insert(0, str(_Path(__file__).resolve().parent))
 
-from _debug_pm_shared import *  # noqa: F401,F403
 import time
 
 from loguru import logger

--- a/apps/worker/scripts/page_memory/debug_pm_stage4_fine_hierarchy.py
+++ b/apps/worker/scripts/page_memory/debug_pm_stage4_fine_hierarchy.py
@@ -20,7 +20,6 @@ from pathlib import Path as _Path
 
 sys.path.insert(0, str(_Path(__file__).resolve().parent))
 
-from _debug_pm_shared import *  # noqa: F401,F403
 import os
 import time
 from pathlib import Path

--- a/apps/worker/scripts/page_memory/debug_pm_stage5_assets.py
+++ b/apps/worker/scripts/page_memory/debug_pm_stage5_assets.py
@@ -20,7 +20,6 @@ from pathlib import Path as _Path
 
 sys.path.insert(0, str(_Path(__file__).resolve().parent))
 
-from _debug_pm_shared import *  # noqa: F401,F403
 import os
 import time
 from dataclasses import dataclass

--- a/apps/worker/scripts/page_memory/debug_pm_stage6_tagging_finalize.py
+++ b/apps/worker/scripts/page_memory/debug_pm_stage6_tagging_finalize.py
@@ -21,7 +21,6 @@ from pathlib import Path as _Path
 
 sys.path.insert(0, str(_Path(__file__).resolve().parent))
 
-from _debug_pm_shared import *  # noqa: F401,F403
 import json
 import os
 import time
@@ -103,8 +102,12 @@ def _run_tagging_for_scope(
     if assets_path.exists():
         try:
             assets_by_page = load_assets_artifact(assets_path)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning(
+                "   failed to load {}; continuing without assets: {}",
+                assets_path,
+                exc,
+            )
 
     # Reuse Stage-4's exact scope contract. Fall back only for old artifacts.
     recorded_pages = prior_scope.get("processing_pages")


### PR DESCRIPTION
## Summary
- Resolve the CodeQL review comments on [#305](https://github.com/Ontos-AI/knowhere/pull/305) (`main` → `staging`) in worker debug scripts.
- Drop unused tracker assignments, a redundant comparison, a duplicate `re` import, and `import *` namespace pollution.
- Replace empty `except` cleanup paths with `unlink(missing_ok=True)` / warning logs, and mark intentional re-exports in `__all__`.

## Test plan
- [ ] Confirm CodeQL no longer flags the previous comments on `debug_parse.py`, `debug_retrieval.py`, and `scripts/page_memory/*`
- [ ] `uv run --all-packages --group lint ruff check apps/worker/scripts/debug_parse.py apps/worker/scripts/debug_retrieval.py apps/worker/scripts/page_memory`
- [ ] `git diff --check`


Made with [Cursor](https://cursor.com)