### PR TITLE
fix: retry failed MinerU URL tasks via direct upload

### DIFF
--- a/apps/worker/app/services/document_parser/providers/mineru/pdf_service.py
+++ b/apps/worker/app/services/document_parser/providers/mineru/pdf_service.py
@@ -18,6 +18,7 @@ from app.services.document_parser.support.parser_log_utils import truncate_log_v
 from shared.core.config import settings
 from shared.core.constants import APIConstants
 from shared.core.exceptions.domain_exceptions import (
+    MinerUTaskFailedException,
     MinerUServiceException,
     StorageServiceException,
     UnavailableException,
@@ -68,6 +69,43 @@ def _log_mineru_url_mode_ingestion_fallback(
         error_type=type(exc).__name__,
         error_message=truncate_log_value(exc),
     ).warning("MinerU URL-mode ingestion setup failed. Falling back to direct upload.")
+
+
+def _log_mineru_url_mode_polling_fallback(
+    s3_key: str,
+    pdf_url: str,
+    batch_id: str,
+    exc: MinerUTaskFailedException,
+) -> None:
+    mineru_logger(
+        "url_mode_polling_fallback",
+        operation="retry_direct_upload_after_parse_failure",
+        source_s3_key=s3_key,
+        source_kind="remote_url" if is_remote(pdf_url) else "local_file",
+        source_path=None if is_remote(pdf_url) else pdf_url,
+        failed_batch_id=batch_id,
+        error_type=type(exc).__name__,
+        error_message=truncate_log_value(exc),
+    ).warning(
+        "MinerU URL-mode polling reported a parse failure. "
+        "Falling back to direct upload."
+    )
+
+
+def _start_direct_upload_task(pdf_url: str, filename: str) -> tuple[str, str]:
+    batch_id, upload_url, token_id = _request_upload_target(pdf_url, filename)
+    _upload_file_to_mineru(pdf_url, filename, upload_url, token_id)
+    return batch_id, token_id
+
+
+def _poll_batch(batch_id: str, token_id: str, output_dir: str) -> None:
+    poll_mineru_task(
+        status_url=f"{settings.MINERU_URL}/extract-results/batch/{batch_id}",
+        task_id=batch_id,
+        output_dir=output_dir,
+        get_status=get_batch_status,
+        preferred_token_id=token_id,
+    )
 
 
 def _inspect_mineru_source_s3_key(s3_key: Optional[str]) -> tuple[Optional[str], bool]:
@@ -394,6 +432,7 @@ def parse_via_full(
 ) -> None:
     batch_id: str | None = None
     token_id: str | None = None
+    used_url_mode = False
     resolved_s3_key = resolve_mineru_source_s3_key(
         s3_key=s3_key,
         local_file_path=None if is_remote(pdf_url) else pdf_url,
@@ -409,6 +448,7 @@ def parse_via_full(
                 "Using S3 URL mode for MinerU ingestion"
             )
             batch_id, token_id = _submit_url_task(presigned_url, filename)
+            used_url_mode = True
         except Exception as exc:
             _log_mineru_url_mode_ingestion_fallback(
                 operation="start_url_mode_ingestion",
@@ -422,18 +462,25 @@ def parse_via_full(
         mineru_logger("ingestion_mode", mode="direct_upload").info(
             "Using direct upload mode for MinerU ingestion"
         )
-        batch_id, upload_url, token_id = _request_upload_target(pdf_url, filename)
-        _upload_file_to_mineru(pdf_url, filename, upload_url, token_id)
+        batch_id, token_id = _start_direct_upload_task(pdf_url, filename)
 
     if batch_id is None or token_id is None:
         raise MinerUServiceException(
             internal_message="MinerU task setup completed without a batch id or token"
         )
 
-    poll_mineru_task(
-        status_url=f"{settings.MINERU_URL}/extract-results/batch/{batch_id}",
-        task_id=batch_id,
-        output_dir=output_dir,
-        get_status=get_batch_status,
-        preferred_token_id=token_id,
-    )
+    try:
+        _poll_batch(batch_id, token_id, output_dir)
+    except MinerUTaskFailedException as exc:
+        if not used_url_mode:
+            raise
+
+        assert resolved_s3_key is not None
+        _log_mineru_url_mode_polling_fallback(
+            s3_key=resolved_s3_key,
+            pdf_url=pdf_url,
+            batch_id=batch_id,
+            exc=exc,
+        )
+        direct_batch_id, direct_token_id = _start_direct_upload_task(pdf_url, filename)
+        _poll_batch(direct_batch_id, direct_token_id, output_dir)

--- a/apps/worker/app/services/document_parser/providers/mineru/task_polling.py
+++ b/apps/worker/app/services/document_parser/providers/mineru/task_polling.py
@@ -16,6 +16,7 @@ from loguru import logger
 
 from shared.core.config import settings
 from shared.core.exceptions.domain_exceptions import (
+    MinerUTaskFailedException,
     MinerUServiceException,
     PDFParsingException,
     TimeoutException,
@@ -183,7 +184,7 @@ def poll_mineru_task(
                         token_id=lease.token_id,
                         error_message=error_message,
                     ).error("MinerU parsing reported failed state")
-                    raise PDFParsingException(
+                    raise MinerUTaskFailedException(
                         user_message="Failed to parse the PDF file",
                         internal_message=f"MinerU failed with state 'failed': {error_message}",
                     )

--- a/apps/worker/tests/unit/test_mineru_pdf_service.py
+++ b/apps/worker/tests/unit/test_mineru_pdf_service.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import Mock, call
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("TMP_PATH", "/tmp/knowhere-test")
+os.environ.setdefault("S3_BUCKET_NAME", "test-uploads")
+os.environ.setdefault("S3_ACCESS_KEY_ID", "test")
+os.environ.setdefault("S3_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("S3_TEMP_PATH", "/tmp")
+
+from app.services.document_parser.providers.mineru import pdf_service
+from shared.core.exceptions.domain_exceptions import (
+    MinerUTaskFailedException,
+    PDFParsingException,
+    TimeoutException,
+)
+
+
+def _configure_url_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Mock:
+    storage = Mock()
+    storage.generate_upload_download_url.return_value = {
+        "download_url": "https://storage.example/signed-source.pdf?secret=value"
+    }
+    storage_factory = Mock(return_value=storage)
+    submit_url_task = Mock(return_value=("url-batch", "url-token"))
+
+    monkeypatch.setattr(
+        pdf_service,
+        "resolve_mineru_source_s3_key",
+        Mock(return_value="jobs/source.pdf"),
+    )
+    monkeypatch.setattr(pdf_service, "JobFileStorage", storage_factory)
+    monkeypatch.setattr(pdf_service, "_submit_url_task", submit_url_task)
+    return submit_url_task
+
+
+def test_url_poll_parse_failure_retries_once_via_direct_upload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    submit_url_task = _configure_url_mode(monkeypatch)
+    parse_failure = MinerUTaskFailedException(
+        user_message="Failed to parse the PDF file",
+        internal_message="MinerU failed with state 'failed'",
+    )
+    poll_mineru_task = Mock(side_effect=[parse_failure, None])
+    request_upload_target = Mock(
+        return_value=("direct-batch", "direct-upload-url", "direct-token")
+    )
+    upload_file = Mock()
+    structured_logger = Mock()
+    bound_logger = Mock()
+    structured_logger.return_value = bound_logger
+
+    monkeypatch.setattr(pdf_service, "poll_mineru_task", poll_mineru_task)
+    monkeypatch.setattr(pdf_service, "_request_upload_target", request_upload_target)
+    monkeypatch.setattr(pdf_service, "_upload_file_to_mineru", upload_file)
+    monkeypatch.setattr(pdf_service, "mineru_logger", structured_logger)
+
+    source_path = str(tmp_path / "source.pdf")
+    output_dir = str(tmp_path / "output")
+    pdf_service.parse_via_full(
+        source_path,
+        "source.pdf",
+        output_dir,
+        s3_key="jobs/source.pdf",
+    )
+
+    submit_url_task.assert_called_once_with(
+        "https://storage.example/signed-source.pdf?secret=value",
+        "source.pdf",
+    )
+    request_upload_target.assert_called_once_with(source_path, "source.pdf")
+    upload_file.assert_called_once_with(
+        source_path,
+        "source.pdf",
+        "direct-upload-url",
+        "direct-token",
+    )
+    assert poll_mineru_task.call_args_list == [
+        call(
+            status_url=(
+                f"{pdf_service.settings.MINERU_URL}"
+                "/extract-results/batch/url-batch"
+            ),
+            task_id="url-batch",
+            output_dir=output_dir,
+            get_status=pdf_service.get_batch_status,
+            preferred_token_id="url-token",
+        ),
+        call(
+            status_url=(
+                f"{pdf_service.settings.MINERU_URL}"
+                "/extract-results/batch/direct-batch"
+            ),
+            task_id="direct-batch",
+            output_dir=output_dir,
+            get_status=pdf_service.get_batch_status,
+            preferred_token_id="direct-token",
+        ),
+    ]
+
+    fallback_calls = [
+        logger_call
+        for logger_call in structured_logger.call_args_list
+        if logger_call.args
+        and logger_call.args[0] == "url_mode_polling_fallback"
+    ]
+    assert len(fallback_calls) == 1
+    assert fallback_calls[0].kwargs["failed_batch_id"] == "url-batch"
+    assert "signed-source" not in repr(fallback_calls[0])
+    bound_logger.warning.assert_any_call(
+        "MinerU URL-mode polling reported a parse failure. "
+        "Falling back to direct upload."
+    )
+
+
+def test_direct_upload_first_poll_parse_failure_does_not_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(pdf_service.settings, "MINERU_UPLOAD_MODE_ENABLED", True)
+    request_upload_target = Mock(
+        return_value=("direct-batch", "direct-upload-url", "direct-token")
+    )
+    upload_file = Mock()
+    parse_failure = MinerUTaskFailedException(
+        user_message="Failed to parse the PDF file",
+        internal_message="MinerU failed with state 'failed'",
+    )
+    poll_mineru_task = Mock(side_effect=parse_failure)
+    submit_url_task = Mock()
+
+    monkeypatch.setattr(pdf_service, "_request_upload_target", request_upload_target)
+    monkeypatch.setattr(pdf_service, "_upload_file_to_mineru", upload_file)
+    monkeypatch.setattr(pdf_service, "poll_mineru_task", poll_mineru_task)
+    monkeypatch.setattr(pdf_service, "_submit_url_task", submit_url_task)
+
+    source_path = str(tmp_path / "source.pdf")
+    with pytest.raises(MinerUTaskFailedException) as exc_info:
+        pdf_service.parse_via_full(
+            source_path,
+            "source.pdf",
+            str(tmp_path / "output"),
+            s3_key="jobs/source.pdf",
+        )
+
+    assert exc_info.value is parse_failure
+    request_upload_target.assert_called_once_with(source_path, "source.pdf")
+    upload_file.assert_called_once()
+    poll_mineru_task.assert_called_once()
+    submit_url_task.assert_not_called()
+
+
+def test_direct_upload_retry_failure_propagates_without_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_url_mode(monkeypatch)
+    url_failure = MinerUTaskFailedException(
+        user_message="Failed to parse the PDF file",
+        internal_message="URL-mode MinerU task failed",
+    )
+    direct_failure = MinerUTaskFailedException(
+        user_message="Failed to parse the PDF file",
+        internal_message="Direct-upload MinerU task failed",
+    )
+    poll_mineru_task = Mock(side_effect=[url_failure, direct_failure])
+    request_upload_target = Mock(
+        return_value=("direct-batch", "direct-upload-url", "direct-token")
+    )
+
+    monkeypatch.setattr(pdf_service, "poll_mineru_task", poll_mineru_task)
+    monkeypatch.setattr(pdf_service, "_request_upload_target", request_upload_target)
+    monkeypatch.setattr(pdf_service, "_upload_file_to_mineru", Mock())
+
+    with pytest.raises(MinerUTaskFailedException) as exc_info:
+        pdf_service.parse_via_full(
+            str(tmp_path / "source.pdf"),
+            "source.pdf",
+            str(tmp_path / "output"),
+            s3_key="jobs/source.pdf",
+        )
+
+    assert exc_info.value is direct_failure
+    request_upload_target.assert_called_once()
+    assert poll_mineru_task.call_count == 2
+
+
+def test_url_poll_success_does_not_direct_upload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_url_mode(monkeypatch)
+    poll_mineru_task = Mock()
+    request_upload_target = Mock()
+    upload_file = Mock()
+
+    monkeypatch.setattr(pdf_service, "poll_mineru_task", poll_mineru_task)
+    monkeypatch.setattr(pdf_service, "_request_upload_target", request_upload_target)
+    monkeypatch.setattr(pdf_service, "_upload_file_to_mineru", upload_file)
+
+    pdf_service.parse_via_full(
+        str(tmp_path / "source.pdf"),
+        "source.pdf",
+        str(tmp_path / "output"),
+        s3_key="jobs/source.pdf",
+    )
+
+    poll_mineru_task.assert_called_once()
+    request_upload_target.assert_not_called()
+    upload_file.assert_not_called()
+
+
+def test_url_poll_timeout_does_not_direct_upload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_url_mode(monkeypatch)
+    timeout = TimeoutException(
+        internal_message="MinerU polling timed out",
+        retry_after=60,
+    )
+    poll_mineru_task = Mock(side_effect=timeout)
+    request_upload_target = Mock()
+    upload_file = Mock()
+
+    monkeypatch.setattr(pdf_service, "poll_mineru_task", poll_mineru_task)
+    monkeypatch.setattr(pdf_service, "_request_upload_target", request_upload_target)
+    monkeypatch.setattr(pdf_service, "_upload_file_to_mineru", upload_file)
+
+    with pytest.raises(TimeoutException) as exc_info:
+        pdf_service.parse_via_full(
+            str(tmp_path / "source.pdf"),
+            "source.pdf",
+            str(tmp_path / "output"),
+            s3_key="jobs/source.pdf",
+        )
+
+    assert exc_info.value is timeout
+    poll_mineru_task.assert_called_once()
+    request_upload_target.assert_not_called()
+    upload_file.assert_not_called()
+
+
+def test_url_poll_other_pdf_error_does_not_direct_upload(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_url_mode(monkeypatch)
+    extraction_failure = PDFParsingException(
+        user_message="Failed to extract MinerU output",
+        internal_message="Invalid ZIP archive",
+    )
+    poll_mineru_task = Mock(side_effect=extraction_failure)
+    request_upload_target = Mock()
+    upload_file = Mock()
+
+    monkeypatch.setattr(pdf_service, "poll_mineru_task", poll_mineru_task)
+    monkeypatch.setattr(pdf_service, "_request_upload_target", request_upload_target)
+    monkeypatch.setattr(pdf_service, "_upload_file_to_mineru", upload_file)
+
+    with pytest.raises(PDFParsingException) as exc_info:
+        pdf_service.parse_via_full(
+            str(tmp_path / "source.pdf"),
+            "source.pdf",
+            str(tmp_path / "output"),
+            s3_key="jobs/source.pdf",
+        )
+
+    assert exc_info.value is extraction_failure
+    poll_mineru_task.assert_called_once()
+    request_upload_target.assert_not_called()
+    upload_file.assert_not_called()

--- a/apps/worker/tests/unit/test_mineru_task_polling.py
+++ b/apps/worker/tests/unit/test_mineru_task_polling.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("TMP_PATH", "/tmp/knowhere-test")
+os.environ.setdefault("S3_BUCKET_NAME", "test-uploads")
+os.environ.setdefault("S3_ACCESS_KEY_ID", "test")
+os.environ.setdefault("S3_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("S3_TEMP_PATH", "/tmp")
+
+from app.services.document_parser.providers.mineru import task_polling
+from shared.core.exceptions.domain_exceptions import (
+    MinerUTaskFailedException,
+    PDFParsingException,
+)
+
+
+def _configure_poll_response(
+    monkeypatch: pytest.MonkeyPatch,
+    response_json: dict[str, object],
+) -> None:
+    lease = Mock(token_id="token-1", api_key="secret")
+    quota_manager = Mock()
+    quota_manager.acquire_request.return_value = lease
+    response = Mock(status_code=200)
+    response.json.return_value = response_json
+    session = Mock()
+    session.get.return_value = response
+
+    monkeypatch.setattr(
+        task_polling,
+        "get_mineru_quota_manager",
+        Mock(return_value=quota_manager),
+    )
+    monkeypatch.setattr(
+        task_polling,
+        "get_mineru_session",
+        Mock(return_value=session),
+    )
+
+
+def test_failed_state_raises_mineru_task_failed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_poll_response(
+        monkeypatch,
+        {
+            "code": 0,
+            "data": {
+                "extract_result": [
+                    {
+                        "state": "failed",
+                        "err_msg": "parsing failed, please try again later",
+                    }
+                ]
+            },
+        },
+    )
+
+    with pytest.raises(MinerUTaskFailedException):
+        task_polling.poll_mineru_task(
+            status_url="https://mineru.example/status",
+            task_id="batch-1",
+            output_dir=str(tmp_path),
+            get_status=task_polling.get_batch_status,
+        )
+
+
+def test_unexpected_status_error_is_not_mineru_task_failed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure_poll_response(monkeypatch, {"code": 0, "data": {}})
+
+    def raise_invalid_status(
+        _response_json: dict[str, object],
+    ) -> dict[str, object] | None:
+        raise ValueError("invalid status payload")
+
+    with pytest.raises(PDFParsingException) as exc_info:
+        task_polling.poll_mineru_task(
+            status_url="https://mineru.example/status",
+            task_id="batch-1",
+            output_dir=str(tmp_path),
+            get_status=raise_invalid_status,
+        )
+
+    assert not isinstance(exc_info.value, MinerUTaskFailedException)

--- a/packages/shared-python/shared/core/exceptions/domain_exceptions.py
+++ b/packages/shared-python/shared/core/exceptions/domain_exceptions.py
@@ -518,6 +518,10 @@ class PDFParsingException(KnowhereException):
         )
 
 
+class MinerUTaskFailedException(PDFParsingException):
+    """MinerU accepted a task but later reported a terminal failed state."""
+
+
 class DocxParsingException(KnowhereException):
     """
     DOCX parsing failed (structure issues).


### PR DESCRIPTION
## Summary
- distinguish terminal MinerU task failures from unrelated PDF polling errors
- retry accepted S3 URL-mode tasks once through MinerU direct upload when polling reports `state=failed`
- preserve direct-upload-first behavior and prevent retry loops, with focused regression coverage

## Test plan
- [x] `uv run --package knowhere-worker-app pytest apps/worker/tests/unit/test_mineru_pdf_service.py apps/worker/tests/unit/test_mineru_task_polling.py -q`
- [x] `uv run ruff check` on changed implementation and test files
- [x] `uv run pyright` on changed implementation and test files
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)