### PR TITLE
fix: keep PyMuPDF asset probe from hanging or dropping results

### DIFF
--- a/apps/worker/app/services/document_agent/tools/probe_page_features.py
+++ b/apps/worker/app/services/document_agent/tools/probe_page_features.py
@@ -29,6 +29,11 @@ _FIGURE_MIN_AREA = 5000.0
 # Near-full-page sparse stroke frames are treated as borders, not figures.
 _FIGURE_FULLPAGE_AREA_RATIO = 0.92
 _FIGURE_FULLPAGE_MAX_PATHS = 25
+# Skip find_tables + drawing clustering on vector/image-dense pages.
+# Clustering ~1e5 strokes is quadratic in a crowded grid cell and exceeds
+# the 300s probe child timeout (EAS lipoprotein consensus PDF page 2).
+_DENSE_DRAWING_LIMIT = 5000
+_DENSE_IMAGE_LIMIT = 200
 # MuPDF ``page.get_texttrace()`` type matching PDF text rendering mode ``3 Tr``.
 _INVISIBLE_TEXT_TRACE_TYPE = 3
 
@@ -257,6 +262,10 @@ def _figure_bboxes_from_drawings(
     return figures
 
 
+def _is_dense_visual_page(*, image_count: int, drawings_count: int) -> bool:
+    return image_count > _DENSE_IMAGE_LIMIT or drawings_count > _DENSE_DRAWING_LIMIT
+
+
 def _probe_visual_assets(
     page: Any,
     page_area: float,
@@ -295,41 +304,45 @@ def _probe_visual_assets(
             image_area += max(box[2] - box[0], 0.0) * max(box[3] - box[1], 0.0)
             bboxes.append({"kind": "image", "bbox": box})
 
-    table_count = 0
-    try:
-        finder = page.find_tables()
-        tables = getattr(finder, "tables", []) or []
-        table_count = len(tables)
-        for table in tables:
-            raw = getattr(table, "bbox", None)
-            if raw is None:
-                continue
-            box = _clip_bbox(
-                float(raw[0]),
-                float(raw[1]),
-                float(raw[2]),
-                float(raw[3]),
-                clip=page_rect,
-            )
-            if _valid_bbox(box):
-                bboxes.append({"kind": "table", "bbox": box})
-    except Exception:
-        table_count = 0
-
     try:
         drawings = page.get_drawings() or []
     except Exception:
         drawings = []
     drawings_count = len(drawings)
-    bboxes.extend(
-        _figure_bboxes_from_drawings(
-            drawings,
-            page_rect=page_rect,
-            page_area=page_area,
-            header_y=header_y,
-            footer_y=footer_y,
-        )
+    dense_visual = _is_dense_visual_page(
+        image_count=image_count, drawings_count=drawings_count
     )
+
+    table_count = 0
+    if not dense_visual:
+        try:
+            finder = page.find_tables()
+            tables = getattr(finder, "tables", []) or []
+            table_count = len(tables)
+            for table in tables:
+                raw = getattr(table, "bbox", None)
+                if raw is None:
+                    continue
+                box = _clip_bbox(
+                    float(raw[0]),
+                    float(raw[1]),
+                    float(raw[2]),
+                    float(raw[3]),
+                    clip=page_rect,
+                )
+                if _valid_bbox(box):
+                    bboxes.append({"kind": "table", "bbox": box})
+        except Exception:
+            table_count = 0
+        bboxes.extend(
+            _figure_bboxes_from_drawings(
+                drawings,
+                page_rect=page_rect,
+                page_area=page_area,
+                header_y=header_y,
+                footer_y=footer_y,
+            )
+        )
 
     coverage = min(image_area / page_area, 1.0) if page_area > 0 else 0.0
     return {
@@ -338,7 +351,7 @@ def _probe_visual_assets(
         "table_count": table_count,
         "drawings_count": drawings_count,
         # Geometry is only used to derive the gate; do not persist bboxes.
-        "has_asset": bool(bboxes),
+        "has_asset": bool(bboxes) or dense_visual,
     }
 
 

--- a/apps/worker/app/services/document_parser/formats/pdf/pymupdf_subprocess.py
+++ b/apps/worker/app/services/document_parser/formats/pdf/pymupdf_subprocess.py
@@ -43,6 +43,8 @@ QUEUE_POLL_INTERVAL_SECONDS = 0.1
 CHILD_EXIT_GRACE_SECONDS = 5
 POST_RESULT_EXIT_GRACE_SECONDS = 5
 POST_KILL_JOIN_GRACE_SECONDS = 1
+# Child can exit 0 before multiprocessing.Queue's feeder flushes; retry once.
+EMPTY_QUEUE_EXIT_RETRIES = 1
 PROCESS_POOL_SIZE = read_pymupdf_max_concurrent()
 PROCESS_POOL_CONTEXT = multiprocessing.get_context("spawn")
 
@@ -130,7 +132,63 @@ def _close_result_queue(result_queue: MultiprocessingQueue) -> None:
         logger.debug(f"Failed to join PyMuPDF result queue thread: {exc}")
 
 
+def _is_empty_queue_exit(exc: Exception) -> bool:
+    if not isinstance(exc, PDFParsingException):
+        return False
+    if exc.details.get("reason") != "SUBPROCESS_CRASH":
+        return False
+    return "exited with code=0 and no result" in (exc.internal_message or "")
+
+
+def _flush_child_result_queue(queue: object) -> None:
+    """Block until the child's queue feeder has written the payload.
+
+    ``Queue.put()`` returns after buffering on a feeder thread. If the child
+    process exits before that thread flushes, the parent sees exitcode=0 and
+    an empty queue (production CRASH on otherwise-healthy PDFs).
+    """
+    close = getattr(queue, "close", None)
+    if not callable(close):
+        return
+    try:
+        close()
+    except Exception:
+        return
+    join_thread = getattr(queue, "join_thread", None)
+    if not callable(join_thread):
+        return
+    try:
+        join_thread()
+    except Exception:
+        pass
+
+
 def _run_worker_in_spawned_process(
+    worker_fn,
+    args: tuple,
+    timeout: int,
+) -> dict:
+    """Spawn an isolated child, retrying once if the result queue is dropped."""
+    last_empty_exit: PDFParsingException | None = None
+    attempts = 1 + EMPTY_QUEUE_EXIT_RETRIES
+    for attempt in range(1, attempts + 1):
+        try:
+            return _run_worker_in_spawned_process_once(worker_fn, args, timeout)
+        except PDFParsingException as exc:
+            if attempt < attempts and _is_empty_queue_exit(exc):
+                logger.warning(
+                    f"[pymupdf-subprocess] retrying fn={worker_fn.__name__} "
+                    f"after empty-queue exit 0 (attempt {attempt}/{attempts})"
+                )
+                last_empty_exit = exc
+                continue
+            raise
+    if last_empty_exit is not None:
+        raise last_empty_exit
+    raise RuntimeError("pymupdf child retry loop exited without a result")
+
+
+def _run_worker_in_spawned_process_once(
     worker_fn,
     args: tuple,
     timeout: int,
@@ -267,6 +325,8 @@ def worker(fn):
                     "error_msg": str(exc),
                 }
             )
+        finally:
+            _flush_child_result_queue(queue)
 
     return wrapped
 

--- a/apps/worker/app/services/document_parser/formats/pdf/pymupdf_subprocess.py
+++ b/apps/worker/app/services/document_parser/formats/pdf/pymupdf_subprocess.py
@@ -159,8 +159,8 @@ def _flush_child_result_queue(queue: object) -> None:
         return
     try:
         join_thread()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug(f"Failed to join PyMuPDF child result queue feeder thread: {exc}")
 
 
 def _run_worker_in_spawned_process(

--- a/apps/worker/tests/unit/test_probe_dense_visual_assets.py
+++ b/apps/worker/tests/unit/test_probe_dense_visual_assets.py
@@ -1,0 +1,88 @@
+"""Dense PDF pages must skip table/figure extraction instead of hanging."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.services.document_agent.tools.probe_page_features import (
+    _DENSE_DRAWING_LIMIT,
+    _DENSE_IMAGE_LIMIT,
+    _probe_visual_assets,
+    _rect_area,
+)
+
+
+class _FakeRect:
+    def __init__(self, x0: float, y0: float, x1: float, y1: float) -> None:
+        self.x0 = x0
+        self.y0 = y0
+        self.x1 = x1
+        self.y1 = y1
+        self.width = x1 - x0
+        self.height = y1 - y0
+
+
+class _FakePage:
+    def __init__(
+        self,
+        *,
+        image_count: int = 0,
+        drawings_count: int = 0,
+    ) -> None:
+        self.rect = _FakeRect(0, 0, 600, 800)
+        self._images = [(index, 0, 0, 0, 0, 0, 0, 0) for index in range(image_count)]
+        self._drawings = [
+            {"rect": _FakeRect(10, 10, 20, 20)} for _ in range(drawings_count)
+        ]
+        self.find_tables_calls = 0
+        self.get_drawings_calls = 0
+
+    def get_images(self, full: bool = True) -> list[tuple[int, ...]]:
+        return self._images
+
+    def get_image_rects(self, _xref: int) -> list[_FakeRect]:
+        return []
+
+    def find_tables(self) -> SimpleNamespace:
+        self.find_tables_calls += 1
+        return SimpleNamespace(tables=[])
+
+    def get_drawings(self) -> list[dict[str, _FakeRect]]:
+        self.get_drawings_calls += 1
+        return self._drawings
+
+
+def test_dense_drawings_skip_tables_and_still_flag_asset() -> None:
+    page = _FakePage(drawings_count=_DENSE_DRAWING_LIMIT + 1)
+    result = _probe_visual_assets(
+        page, _rect_area(page.rect), header_y=None, footer_y=None
+    )
+
+    assert page.find_tables_calls == 0
+    assert result["drawings_count"] == _DENSE_DRAWING_LIMIT + 1
+    assert result["table_count"] == 0
+    assert result["has_asset"] is True
+
+
+def test_dense_images_skip_tables() -> None:
+    page = _FakePage(image_count=_DENSE_IMAGE_LIMIT + 1)
+    result = _probe_visual_assets(
+        page, _rect_area(page.rect), header_y=None, footer_y=None
+    )
+
+    assert page.find_tables_calls == 0
+    assert result["image_count"] == _DENSE_IMAGE_LIMIT + 1
+    assert result["table_count"] == 0
+    assert result["has_asset"] is True
+
+
+def test_normal_page_still_runs_table_finder() -> None:
+    page = _FakePage(image_count=2, drawings_count=8)
+    result = _probe_visual_assets(
+        page, _rect_area(page.rect), header_y=None, footer_y=None
+    )
+
+    assert page.find_tables_calls == 1
+    assert result["image_count"] == 2
+    assert result["drawings_count"] == 8
+    assert result["has_asset"] is False

--- a/apps/worker/tests/unit/test_pymupdf_subprocess_queue.py
+++ b/apps/worker/tests/unit/test_pymupdf_subprocess_queue.py
@@ -1,0 +1,98 @@
+"""Child workers must flush the multiprocessing queue before exiting."""
+
+from __future__ import annotations
+
+from app.services.document_parser.formats.pdf.pymupdf_subprocess import (
+    _is_empty_queue_exit,
+    worker,
+)
+from shared.core.exceptions.domain_exceptions import PDFParsingException
+
+
+class _FakeQueue:
+    def __init__(self) -> None:
+        self.items: list[object] = []
+        self.closed = False
+        self.joined = False
+
+    def put(self, item: object) -> None:
+        self.items.append(item)
+
+    def close(self) -> None:
+        self.closed = True
+
+    def join_thread(self) -> None:
+        self.joined = True
+
+
+def test_worker_decorator_flushes_queue_after_success() -> None:
+    @worker
+    def _ok(queue: _FakeQueue, value: str) -> None:
+        queue.put({"ok": True, "value": value})
+
+    queue = _FakeQueue()
+    _ok(queue, "payload")
+
+    assert queue.items == [{"ok": True, "value": "payload"}]
+    assert queue.closed is True
+    assert queue.joined is True
+
+
+def test_worker_decorator_flushes_queue_after_failure() -> None:
+    @worker
+    def _boom(queue: _FakeQueue) -> None:
+        raise RuntimeError("child failed")
+
+    queue = _FakeQueue()
+    _boom(queue)
+
+    assert queue.items[0]["ok"] is False
+    assert queue.items[0]["error_type"] == "RuntimeError"
+    assert queue.closed is True
+    assert queue.joined is True
+
+
+def test_empty_queue_exit_is_retryable() -> None:
+    exc = PDFParsingException(
+        user_message="Failed to process your document. Please try again.",
+        reason="SUBPROCESS_CRASH",
+        internal_message=(
+            "pymupdf child exited with code=0 and no result: "
+            "fn=_probe_assets_worker, pid=2049"
+        ),
+    )
+    assert _is_empty_queue_exit(exc) is True
+
+
+def test_nonzero_crash_is_not_retryable() -> None:
+    exc = PDFParsingException(
+        user_message="Failed to process your document. Please try again.",
+        reason="SUBPROCESS_CRASH",
+        internal_message="pymupdf child exited with code=-9 and no result: fn=x, pid=1",
+    )
+    assert _is_empty_queue_exit(exc) is False
+
+
+def test_empty_queue_exit_retries_once(monkeypatch: object) -> None:
+    import app.services.document_parser.formats.pdf.pymupdf_subprocess as subprocess_mod
+
+    calls = {"n": 0}
+    crash = PDFParsingException(
+        user_message="Failed to process your document. Please try again.",
+        reason="SUBPROCESS_CRASH",
+        internal_message=(
+            "pymupdf child exited with code=0 and no result: "
+            "fn=_probe_assets_worker, pid=2049"
+        ),
+    )
+
+    def _once(_worker_fn: object, _args: tuple, _timeout: int) -> dict:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise crash
+        return {"ok": True, "assets": []}
+
+    monkeypatch.setattr(subprocess_mod, "_run_worker_in_spawned_process_once", _once)
+    result = subprocess_mod._run_worker_in_spawned_process(lambda: None, (), 10)
+    assert result == {"ok": True, "assets": []}
+    assert calls["n"] == 2

--- a/apps/worker/tests/unit/test_pymupdf_subprocess_queue.py
+++ b/apps/worker/tests/unit/test_pymupdf_subprocess_queue.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-from app.services.document_parser.formats.pdf.pymupdf_subprocess import (
-    _is_empty_queue_exit,
-    worker,
-)
+import app.services.document_parser.formats.pdf.pymupdf_subprocess as subprocess_mod
 from shared.core.exceptions.domain_exceptions import PDFParsingException
 
 
@@ -26,7 +23,7 @@ class _FakeQueue:
 
 
 def test_worker_decorator_flushes_queue_after_success() -> None:
-    @worker
+    @subprocess_mod.worker
     def _ok(queue: _FakeQueue, value: str) -> None:
         queue.put({"ok": True, "value": value})
 
@@ -39,7 +36,7 @@ def test_worker_decorator_flushes_queue_after_success() -> None:
 
 
 def test_worker_decorator_flushes_queue_after_failure() -> None:
-    @worker
+    @subprocess_mod.worker
     def _boom(queue: _FakeQueue) -> None:
         raise RuntimeError("child failed")
 
@@ -61,7 +58,7 @@ def test_empty_queue_exit_is_retryable() -> None:
             "fn=_probe_assets_worker, pid=2049"
         ),
     )
-    assert _is_empty_queue_exit(exc) is True
+    assert subprocess_mod._is_empty_queue_exit(exc) is True
 
 
 def test_nonzero_crash_is_not_retryable() -> None:
@@ -70,12 +67,10 @@ def test_nonzero_crash_is_not_retryable() -> None:
         reason="SUBPROCESS_CRASH",
         internal_message="pymupdf child exited with code=-9 and no result: fn=x, pid=1",
     )
-    assert _is_empty_queue_exit(exc) is False
+    assert subprocess_mod._is_empty_queue_exit(exc) is False
 
 
 def test_empty_queue_exit_retries_once(monkeypatch: object) -> None:
-    import app.services.document_parser.formats.pdf.pymupdf_subprocess as subprocess_mod
-
     calls = {"n": 0}
     crash = PDFParsingException(
         user_message="Failed to process your document. Please try again.",


### PR DESCRIPTION
## Summary
- Skip `find_tables` and drawing clustering on image/vector-dense pages so `_probe_assets_worker` stays under the 300s child timeout (production lipoprotein PDF page 2 has ~114k drawings).
- Flush the multiprocessing result queue in the child after `put()`, and retry once on `exitcode=0` with an empty queue so a healthy probe is not reported as `SUBPROCESS_CRASH`.

## Test plan
- [x] `uv run pytest tests/unit/test_probe_dense_visual_assets.py tests/unit/test_pymupdf_subprocess_queue.py tests/unit/test_probe_visible_text.py`
- [x] Local production path: lipoprotein PDF probe finished in 21.8s (previously timed out at 300s)
- [x] Local production path: nucleic PDF probe succeeded 3/3
- [ ] Staging re-parse of `job_6265564f67e8` and `job_83eb3d464064` after merge


Made with [Cursor](https://cursor.com)