### PR TITLE
fix: retry PDF shard split after source object out of range

### DIFF
--- a/apps/worker/app/services/document_parser/formats/pdf/shard_splitter.py
+++ b/apps/worker/app/services/document_parser/formats/pdf/shard_splitter.py
@@ -12,6 +12,9 @@ from loguru import logger
 if TYPE_CHECKING:
     from app.services.document_agent.manifest import Shard
 
+_SOURCE_OBJECT_OUT_OF_RANGE = "source object number out of range"
+_REWRITTEN_SOURCE_NAME = "_rewritten_source.pdf"
+
 
 @dataclass
 class MergedShard:
@@ -46,6 +49,11 @@ def map_agent_shards(
     ]
 
 
+def _is_source_object_out_of_range(exc: BaseException) -> bool:
+    """True only for MuPDF xref copy failure during insert_pdf."""
+    return isinstance(exc, RuntimeError) and _SOURCE_OBJECT_OUT_OF_RANGE in str(exc)
+
+
 def split_pdf(
     pdf_path: str,
     shards: list[MergedShard],
@@ -69,6 +77,36 @@ def split_pdf(
           ``None`` when no pages are excluded.
     """
     doc = pymupdf.open(pdf_path)
+    rewritten_path: str | None = None
+    try:
+        try:
+            return _extract_shards(doc, shards, work_dir, exclude_pages)
+        except RuntimeError as exc:
+            if not _is_source_object_out_of_range(exc):
+                raise
+            rewritten_path = os.path.join(work_dir, _REWRITTEN_SOURCE_NAME)
+            logger.warning(
+                "PDF split hit source object number out of range; "
+                "rewriting a clean copy and retrying once"
+            )
+            doc.save(rewritten_path, garbage=4, deflate=True)
+    finally:
+        doc.close()
+
+    assert rewritten_path is not None
+    rewritten = pymupdf.open(rewritten_path)
+    try:
+        return _extract_shards(rewritten, shards, work_dir, exclude_pages)
+    finally:
+        rewritten.close()
+
+
+def _extract_shards(
+    doc: pymupdf.Document,
+    shards: list[MergedShard],
+    work_dir: str,
+    exclude_pages: set[int] | None,
+) -> tuple[list[str], dict[int, int] | None]:
     paths: list[str] = []
     page_remap: dict[int, int] | None = None
 
@@ -79,10 +117,10 @@ def split_pdf(
             f"{sorted(exclude_pages)}"
         )
 
-    try:
-        global_new_idx = 0  # running counter across all shards
-        for shard in shards:
-            sub_doc = pymupdf.open()
+    global_new_idx = 0  # running counter across all shards
+    for shard in shards:
+        sub_doc = pymupdf.open()
+        try:
             shard_included = 0
             for page_num in range(shard.page_start, shard.page_end + 1):
                 if exclude_pages and page_num in exclude_pages:
@@ -105,15 +143,14 @@ def split_pdf(
                 logger.warning(
                     f"  ⚠️ shard_{shard.shard_index}: all pages excluded, skipping"
                 )
+        finally:
             sub_doc.close()
 
-            excluded_in_shard = shard.page_count - shard_included
-            logger.info(
-                f"  ✂️ shard_{shard.shard_index}: "
-                f"pages {shard.page_start}-{shard.page_end} "
-                f"({shard_included} included"
-                f"{f', {excluded_in_shard} excluded' if excluded_in_shard else ''})"
-            )
-    finally:
-        doc.close()
+        excluded_in_shard = shard.page_count - shard_included
+        logger.info(
+            f"  ✂️ shard_{shard.shard_index}: "
+            f"pages {shard.page_start}-{shard.page_end} "
+            f"({shard_included} included"
+            f"{f', {excluded_in_shard} excluded' if excluded_in_shard else ''})"
+        )
     return paths, page_remap

--- a/apps/worker/tests/unit/test_pdf_split_object_out_of_range.py
+++ b/apps/worker/tests/unit/test_pdf_split_object_out_of_range.py
@@ -1,0 +1,131 @@
+"""PDF split retries once after MuPDF xref copy failure."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pymupdf
+import pytest
+
+from app.services.document_parser.formats.pdf.shard_splitter import (
+    MergedShard,
+    _is_source_object_out_of_range,
+    split_pdf,
+)
+
+_OBJECT_OUT_OF_RANGE = RuntimeError("code=4: source object number out of range")
+_CUSTOMER_PDF = Path(
+    "/home/suguan/.cursor/Exercise_Prescription_in_Cardiac_Rehabilitation.pdf"
+)
+
+
+def _write_pages(path: Path, page_count: int) -> None:
+    doc = pymupdf.open()
+    for index in range(page_count):
+        page = doc.new_page(width=72, height=72)
+        page.insert_text((12, 24), f"page-{index + 1}")
+    doc.save(path)
+    doc.close()
+
+
+def _page_count(path: str) -> int:
+    doc = pymupdf.open(path)
+    try:
+        return doc.page_count
+    finally:
+        doc.close()
+
+
+def test_source_object_matcher_is_specific() -> None:
+    assert _is_source_object_out_of_range(_OBJECT_OUT_OF_RANGE) is True
+    assert (
+        _is_source_object_out_of_range(RuntimeError("code=7: syntax error")) is False
+    )
+    assert _is_source_object_out_of_range(ValueError(_OBJECT_OUT_OF_RANGE.args[0])) is False
+
+
+def test_split_pdf_copies_pages(tmp_path: Path) -> None:
+    source = tmp_path / "source.pdf"
+    _write_pages(source, 3)
+    work_dir = tmp_path / "shards"
+    work_dir.mkdir()
+
+    paths, remap = split_pdf(
+        str(source),
+        [MergedShard(0, 1, 2), MergedShard(1, 3, 3)],
+        str(work_dir),
+    )
+
+    assert remap is None
+    assert [Path(path).name for path in paths] == ["shard_0.pdf", "shard_1.pdf"]
+    assert _page_count(paths[0]) == 2
+    assert _page_count(paths[1]) == 1
+    assert not (work_dir / "_rewritten_source.pdf").exists()
+
+
+def test_split_pdf_rewrites_once_on_object_out_of_range(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source.pdf"
+    _write_pages(source, 2)
+    work_dir = tmp_path / "shards"
+    work_dir.mkdir()
+
+    real_insert = pymupdf.Document.insert_pdf
+    calls = {"n": 0}
+
+    def _insert_pdf(self: pymupdf.Document, *args: object, **kwargs: object) -> None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _OBJECT_OUT_OF_RANGE
+        real_insert(self, *args, **kwargs)
+
+    monkeypatch.setattr(pymupdf.Document, "insert_pdf", _insert_pdf)
+
+    paths, remap = split_pdf(
+        str(source),
+        [MergedShard(0, 1, 2)],
+        str(work_dir),
+    )
+
+    assert remap is None
+    assert calls["n"] == 3  # fail once, then copy both pages from rewritten source
+    assert (work_dir / "_rewritten_source.pdf").exists()
+    assert len(paths) == 1
+    assert _page_count(paths[0]) == 2
+
+
+def test_split_pdf_does_not_catch_other_runtime_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source.pdf"
+    _write_pages(source, 1)
+    work_dir = tmp_path / "shards"
+    work_dir.mkdir()
+
+    def _insert_pdf(self: pymupdf.Document, *args: object, **kwargs: object) -> None:
+        raise RuntimeError("code=7: syntax error")
+
+    monkeypatch.setattr(pymupdf.Document, "insert_pdf", _insert_pdf)
+
+    with pytest.raises(RuntimeError, match="syntax error"):
+        split_pdf(str(source), [MergedShard(0, 1, 1)], str(work_dir))
+
+    assert not (work_dir / "_rewritten_source.pdf").exists()
+
+
+@pytest.mark.skipif(not _CUSTOMER_PDF.exists(), reason="local Quartz incremental PDF not present")
+def test_split_incremental_quartz_pdf_around_failing_page(tmp_path: Path) -> None:
+    work_dir = tmp_path / "shards"
+    work_dir.mkdir()
+
+    paths, remap = split_pdf(
+        str(_CUSTOMER_PDF),
+        [MergedShard(0, 40, 50)],
+        str(work_dir),
+    )
+
+    assert remap is None
+    assert len(paths) == 1
+    assert _page_count(paths[0]) == 11
+    assert (work_dir / "_rewritten_source.pdf").exists()


### PR DESCRIPTION
## Summary
- Catch only PyMuPDF `RuntimeError: source object number out of range` during `pdf.split` `insert_pdf`.
- Rewrite the source once with `garbage=4` and retry the shard split; all other PDF errors still fail as before.
- This unblocks incremental Quartz/AppendMode PDFs that Chrome can open but PyMuPDF cannot copy objects from (prod: `Exercise_Prescription_in_Cardiac_Rehabilitation.pdf` / `job_e6d257afa2ae`).

## Test plan
- [x] `uv run pytest apps/worker/tests/unit/test_pdf_split_object_out_of_range.py`
- [x] Full 196-page local split of the customer PDF succeeds after one rewrite
- [ ] Confirm a normal PDF still splits without writing `_rewritten_source.pdf`
- [ ] After deploy, re-run `job_e6d257afa2ae` / `Exercise_Prescription_in_Cardiac_Rehabilitation.pdf` and confirm `pdf.split` no longer fails with `code=4`
