### PR TITLE
Reduce duplicate visibility watchdog log noise

### DIFF
--- a/apps/worker/app/core/visibility_recovery_watchdog.py
+++ b/apps/worker/app/core/visibility_recovery_watchdog.py
@@ -46,9 +46,10 @@ def run_visibility_recovery_watchdog() -> None:
         while True:
             try:
                 result: VisibilityRecoveryResult = restore_expired_reservations()
-                logger.bind(**result).info(
-                    "Expired Celery reservation recovery sweep attempted"
-                )
+                if result["status"] == "attempted":
+                    logger.bind(**result).debug(
+                        "Expired Celery reservation recovery sweep attempted"
+                    )
             except Exception:
                 logger.exception("Expired Celery reservation recovery sweep failed")
             finally:

--- a/packages/shared-python/shared/services/redis/periodic_task_lock.py
+++ b/packages/shared-python/shared/services/redis/periodic_task_lock.py
@@ -105,7 +105,7 @@ def periodic_task_lock(
     if acquired:
         logger.debug(f"periodic_task_lock: acquired for task='{task_name}', ttl={ttl}s")
     else:
-        logger.info(
+        logger.debug(
             f"periodic_task_lock: task='{task_name}' already running in this "
             "window (duplicate Beat firing) — skipping"
         )


### PR DESCRIPTION
## Summary

- suppress normal duplicate Beat lock skips from INFO logs
- log successful visibility-recovery attempts at DEBUG only
- keep actual recovery exceptions at ERROR

The Redis idempotency lock still prevents duplicate recovery work; this only removes expected coordination chatter from the normal log stream.

Tests: `uv run pytest tests/contract/test_visibility_recovery_watchdog_contract.py tests/contract/test_visibility_recovery_contract.py` (4 passed).
