### PR TITLE
hotfix(retrieval): normalize psycopg2 database URL

### DIFF
--- a/apps/api/tests/contract/test_retrieval_lazy_snapshot_quality_contract.py
+++ b/apps/api/tests/contract/test_retrieval_lazy_snapshot_quality_contract.py
@@ -11,6 +11,7 @@ from shared.services.retrieval.nav.nav_knowhere import (
     NamespaceKnowhereProvider,
     SectionRow,
     UnitRow,
+    knowhere_database_url,
 )
 from shared.services.retrieval.nav.nav_map_scores import (
     build_score_units,
@@ -174,3 +175,18 @@ def test_streaming_scorer_preserves_duplicate_id_eager_semantics() -> None:
     }
 
     assert score_unit_stream_hybrid_all(lambda: rows, "alpha beta") == eager_scores
+
+
+def test_native_chunk_store_strips_async_driver_from_database_url(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://prod-user:prod-password@db.example/knowhere",
+    )
+    monkeypatch.delenv("KNOWHERE_DATABASE_URL", raising=False)
+
+    assert (
+        knowhere_database_url()
+        == "postgresql://prod-user:prod-password@db.example/knowhere"
+    )

--- a/packages/shared-python/shared/services/retrieval/nav/nav_knowhere.py
+++ b/packages/shared-python/shared/services/retrieval/nav/nav_knowhere.py
@@ -132,7 +132,11 @@ def knowhere_database_url() -> str:
         or str(os.environ.get("DATABASE_URL") or "").strip()
     )
     if configured:
-        return configured.replace("postgresql+asyncpg", "postgresql+psycopg2")
+        # ``ReadOnlyChunkStore`` uses psycopg2's native connector, which
+        # accepts libpq URLs but not SQLAlchemy's ``+driver`` suffix.
+        return configured.replace("postgresql+asyncpg://", "postgresql://", 1).replace(
+            "postgresql+psycopg2://", "postgresql://", 1
+        )
     return _DEFAULT_DSN
 
 


### PR DESCRIPTION
## Summary

Hotfix the production retrieval timeout/memory failure for namespaces around 60,000 chunks.

- Load map-nav chunk metadata/index in bounded 10,000-row keyset pages instead of one oversized snapshot query.
- Lazy-load section payloads during scoring and release each section after use.
- Stream corpus BM25/RRF scoring without retaining all raw chunk payloads.
- Preserve the existing BM25 formulas, channel weights, RRF fusion, ordering, tie-breaking, and hydrated retrieval inputs.

## Verification

- Focused retrieval contracts: `3 passed`.
- Full repository contracts: `651 passed, 14 warnings`.
- Ruff and Pyright passed.
- Real local 60k PostgreSQL corpus: lazy retrieval completed successfully with substantially lower peak RSS; eager and lazy map/unit scores and selected results were identical.
- Real local 600k PostgreSQL corpus: bounded loading completed without SQL timeout or OOM; this measured 111.5s loading, 64.1s scoring, 175.6s total, and 645.7 MiB peak RSS. The larger-scale optimization is tracked separately in #340.

## Quality guarantee

No ranking or candidate-selection behavior is intentionally changed. Exact eager/lazy parity is covered by contract tests.
