### PR TITLE
fix: support backfill script in api image

### DIFF
--- a/apps/api/scripts/backfill_map_unit_indexes.py
+++ b/apps/api/scripts/backfill_map_unit_indexes.py
@@ -15,10 +15,22 @@ import sys
 from pathlib import Path
 
 
+def _resolve_shared_root(api_root: Path) -> Path:
+    """Resolve the shared package in source checkouts and runtime images."""
+    runtime_shared_root = api_root / "packages" / "shared-python"
+    if runtime_shared_root.is_dir():
+        return runtime_shared_root
+
+    repository_shared_root = api_root.parents[1] / "packages" / "shared-python"
+    if repository_shared_root.is_dir():
+        return repository_shared_root
+
+    raise RuntimeError(f"Could not locate shared-python package from {api_root}")
+
+
 def _bootstrap_python_path() -> None:
     api_root = Path(__file__).resolve().parents[1]
-    repo_root = api_root.parents[1]
-    shared_root = repo_root / "packages" / "shared-python"
+    shared_root = _resolve_shared_root(api_root)
     for path in (api_root, shared_root):
         value = os.fspath(path)
         if value not in sys.path:
@@ -44,7 +56,9 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Build and commit each current revision index.",
     )
-    parser.add_argument("--document-id", default="", help="Limit the backfill to one document.")
+    parser.add_argument(
+        "--document-id", default="", help="Limit the backfill to one document."
+    )
     return parser
 
 
@@ -62,7 +76,9 @@ def backfill_map_unit_indexes(*, apply: bool, document_id: str = "") -> int:
     documents = _load_documents(document_id)
     if not apply:
         for document in documents:
-            print(f"would backfill document={document.document_id} revision={document.current_job_result_id}")
+            print(
+                f"would backfill document={document.document_id} revision={document.current_job_result_id}"
+            )
         return len(documents)
 
     session_factory = get_sync_session_factory()

--- a/apps/api/tests/contract/test_backfill_map_unit_indexes_contract.py
+++ b/apps/api/tests/contract/test_backfill_map_unit_indexes_contract.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_backfill_script_resolves_shared_package_from_runtime_image_layout(
+    tmp_path: Path,
+) -> None:
+    from scripts.backfill_map_unit_indexes import _resolve_shared_root
+
+    api_root = tmp_path / "app"
+    shared_root = api_root / "packages" / "shared-python"
+    shared_root.mkdir(parents=True)
+
+    assert _resolve_shared_root(api_root) == shared_root
+
+
+def test_backfill_script_resolves_shared_package_from_source_checkout_layout(
+    tmp_path: Path,
+) -> None:
+    from scripts.backfill_map_unit_indexes import _resolve_shared_root
+
+    repository_root = tmp_path / "repository"
+    api_root = repository_root / "apps" / "api"
+    shared_root = repository_root / "packages" / "shared-python"
+    shared_root.mkdir(parents=True)
+
+    assert _resolve_shared_root(api_root) == shared_root


### PR DESCRIPTION
## Summary

- fix `backfill_map_unit_indexes.py` for the production API image layout
- resolve `packages/shared-python` from both the source checkout and `/app` runtime image
- add contract coverage for both layouts
- unblock the post-deploy operation documented by PR #344

## Verification

- `PYTHONPATH=apps/api:packages/shared-python /home/suguan/github.com/ontosAI/knowhere/.venv/bin/pytest -q apps/api/tests/contract/test_backfill_map_unit_indexes_contract.py`
- Ruff format and check passed for changed files.
- Production read-only inventory task using `v1.0.32-prod` reproduced the container-path `IndexError`; no backfill writes were performed.

## Deployment Notes

- no database migration or API contract changes
- deploy this fix together with the existing PR #344 release line, then rerun the read-only inventory before canary/full backfill
- the prior temporary task definition `knowhere-api-prod-backfill:1` can be deregistered after the operation plan is finalized; it was not used for writes

## Checklist

- [x] Tests were added or updated when behavior changed
- [ ] Public docs, examples, or OpenAPI contracts were updated when needed
- [x] Database migrations are idempotent and safe to deploy (no migration changed)
- [x] Logs, errors, and validation paths avoid leaking secrets or user data
- [x] The pull request description explains any breaking or user-visible change
