### PR TITLE
feat: add OrcaRouter as a first-class LLM provider

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -85,12 +85,14 @@ GPT_API_KEY=
 GLM_API_KEY=
 ALI_API_KEYS=
 ARK_API_KEY=
+ORCA_API_KEY=
 
 # Optional overrides:
 # DS_URL=https://api.deepseek.com/v1
 # GLM_URL=https://open.bigmodel.cn/api/paas/v4
 # ALI_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 # ARK_URL=https://ark.cn-beijing.volces.com/api/v3/chat/completions
+# ORCA_URL=https://api.orcarouter.ai/v1
 # NORMOL_MODEL=deepseek-v4-flash
 # HIERARCHY_LLM_MODEL=
 # VLM for image/OCR flows. Default qwen3.6-flash; alternate qwen3-vl-32b-instruct

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -78,12 +78,14 @@ GPT_API_KEY=
 GLM_API_KEY=
 ALI_API_KEYS=
 ARK_API_KEY=
+ORCA_API_KEY=
 
 # Optional overrides:
 # DS_URL=https://api.deepseek.com/v1
 # GLM_URL=https://open.bigmodel.cn/api/paas/v4
 # ALI_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 # ARK_URL=https://ark.cn-beijing.volces.com/api/v3/chat/completions
+# ORCA_URL=https://api.orcarouter.ai/v1
 # NORMOL_MODEL=deepseek-v4-flash
 # HIERARCHY_LLM_MODEL=
 # VLM for page tagging, OCR, chart/table bbox probes, and image flows.

--- a/packages/shared-python/shared/core/config/ai.py
+++ b/packages/shared-python/shared/core/config/ai.py
@@ -16,6 +16,10 @@ class AIConfig(BaseModel):
         default="https://api.deepseek.com/v1", description="DeepSeek API URL"
     )
     GPT_API_KEY: str = Field(default="", description="OpenAI API key")
+    ORCA_API_KEY: str = Field(default="", description="OrcaRouter API key")
+    ORCA_URL: str = Field(
+        default="https://api.orcarouter.ai/v1", description="OrcaRouter API URL"
+    )
     # Default behavior: text/table summaries use deepseek-v4-flash. Hierarchy parsing
     # can be overridden independently with HIERARCHY_LLM_MODEL. Existing
     # environment overrides for NORMOL_MODEL / HIERARCHY_LLM_MODEL /

--- a/packages/shared-python/shared/services/ai/openai_compatible_client_sync.py
+++ b/packages/shared-python/shared/services/ai/openai_compatible_client_sync.py
@@ -156,6 +156,10 @@ class OpenAICompatibleClientSync:
         if "doubao" in model_lower or model_lower.startswith("ep-"):
             return self._strip_chat_completions(getattr(settings, "ARK_URL", None))
 
+        if "orcarouter" in model_lower:
+            orca_base = getattr(settings, "ORCA_URL", "https://api.orcarouter.ai/v1")
+            return self._strip_chat_completions(orca_base)
+
         return self._strip_chat_completions(settings.DS_URL)
 
     def _resolve_direct_api_key(
@@ -172,6 +176,9 @@ class OpenAICompatibleClientSync:
 
         if "doubao" in model_lower or model_lower.startswith("ep-"):
             return getattr(settings, "ARK_API_KEY", None)
+
+        if "orcarouter" in model_lower:
+            return getattr(settings, "ORCA_API_KEY", None)
 
         return settings.DS_KEY
 

--- a/packages/shared-python/shared/tests/test_openai_client_routing.py
+++ b/packages/shared-python/shared/tests/test_openai_client_routing.py
@@ -1,0 +1,64 @@
+"""Unit tests for OpenAI-compatible provider credential routing (no live API)."""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("TMP_PATH", "/tmp/knowhere-test")
+os.environ.setdefault("S3_BUCKET_NAME", "test-uploads")
+os.environ.setdefault("S3_ACCESS_KEY_ID", "test")
+os.environ.setdefault("S3_SECRET_ACCESS_KEY", "test")
+os.environ.setdefault("S3_TEMP_PATH", "/tmp")
+
+from shared.services.ai.openai_compatible_client_sync import (  # noqa: E402
+    OpenAICompatibleClientSync,
+)
+
+
+def _client_with(model: str) -> OpenAICompatibleClientSync:
+    return OpenAICompatibleClientSync(default_model=model)
+
+
+def test_orcarouter_model_resolves_base_url_and_api_key() -> None:
+    """orcarouter/* models route to the OrcaRouter endpoint and ORCA_API_KEY."""
+    fake_settings = SimpleNamespace(
+        ORCA_URL="https://api.orcarouter.ai/v1",
+        ORCA_API_KEY="orca-test-key",
+        DS_URL="https://api.deepseek.com/v1",
+        DS_KEY="ds-test-key",
+    )
+    client = _client_with("orcarouter/fusion")
+    with patch(
+        "shared.services.ai.openai_compatible_client_sync.settings",
+        fake_settings,
+    ):
+        assert client._resolve_base_url("orcarouter/fusion", None) == (
+            "https://api.orcarouter.ai/v1"
+        )
+        assert client._resolve_direct_api_key("orcarouter/fusion", None) == (
+            "orca-test-key"
+        )
+
+
+def test_non_orcarouter_model_keeps_existing_routing() -> None:
+    """Models without the orcarouter prefix keep the DeepSeek defaults."""
+    fake_settings = SimpleNamespace(
+        DS_URL="https://api.deepseek.com/v1",
+        DS_KEY="ds-test-key",
+        GLM_URL="https://open.bigmodel.cn/api/paas/v4",
+        GLM_API_KEY="glm-test-key",
+    )
+    client = _client_with("deepseek-v4-flash")
+    with patch(
+        "shared.services.ai.openai_compatible_client_sync.settings",
+        fake_settings,
+    ):
+        assert client._resolve_base_url("deepseek-v4-flash", None) == (
+            "https://api.deepseek.com/v1"
+        )
+        assert client._resolve_direct_api_key("deepseek-v4-flash", None) == (
+            "ds-test-key"
+        )


### PR DESCRIPTION
## Summary

Knowhere describes itself as **"the memory layer between complex, dirty documents and AI agents."** The agents consuming that memory make a steady stream of LLM/VLM calls through Knowhere's parsing, page-memory, and map-nav retrieval pipelines. Today those calls are routed to a handful of named providers — DeepSeek, DashScope/Qwen, Zhipu GLM, Volcengine ARK — by model-name prefix in `OpenAICompatibleClientSync`, with credentials supplied through `AIConfig` env vars. There is no way to run that traffic through a gateway without treating it as an anonymous custom base URL.

This PR adds **OrcaRouter** as a first-class named provider on exactly that same surface. A self-hoster sets `ORCA_API_KEY`, points `NORMOL_MODEL` (or any parse/retrieval model) at an `orcarouter/*` model, and every text and vision call routes through the OrcaRouter gateway — no application code changes, no base-URL plumbing.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means Knowhere users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What changed

- `packages/shared-python/shared/core/config/ai.py` — new `ORCA_API_KEY` and `ORCA_URL` (default `https://api.orcarouter.ai/v1`) on `AIConfig`, mirroring `DS_KEY`/`DS_URL`.
- `packages/shared-python/shared/services/ai/openai_compatible_client_sync.py` — `orcarouter/*` model names resolve to the OrcaRouter base URL and `ORCA_API_KEY`, the same way the existing `glm` / `doubao` / `ep-` branches route to GLM and ARK. This covers the parsing summarizer, page-memory VLM calls, and the map-nav retrieval backend, all of which go through `get_openai_client`.
- `apps/api/.env.example` / `apps/worker/.env.example` — document `ORCA_API_KEY` and `ORCA_URL`.
- `packages/shared-python/shared/tests/test_openai_client_routing.py` — unit tests asserting `orcarouter/*` resolves to OrcaRouter credentials and that non-OrcaRouter models keep existing DeepSeek routing.

## Verification

- `ruff check apps packages` — all checks passed.
- `pyright --project pyproject.toml` on the full CI path — 0 errors.
- `pytest packages/shared-python/shared/tests/test_openai_client_routing.py` (+ related `test_nav_llm_backend.py`, `test_llm_config.py`) — passed.
- Live test through the real code path (`get_openai_client(model="orcarouter/fusion")`) against `https://api.orcarouter.ai/v1` with a real key returned `content='OK'` with token usage — HTTP 200.

## Deployment Notes

- New optional environment variables: `ORCA_API_KEY`, `ORCA_URL` (defaults to `https://api.orcarouter.ai/v1`). No existing variable is changed; fully backwards compatible. No migrations, queue, or storage changes.

## Checklist

- [x] Tests were added or updated when behavior changed
- [x] Public docs, examples, or OpenAPI contracts were updated when needed
- [x] Database migrations are idempotent and safe to deploy
- [x] Logs, errors, and validation paths avoid leaking secrets or user data
- [x] The pull request description explains any breaking or user-visible change

---

To try it: set `ORCA_API_KEY` and e.g. `NORMOL_MODEL=orcarouter/fusion` in `apps/api/.env` / `apps/worker/.env`.

I'm an engineer on the OrcaRouter team. Feedback welcome — Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
