### PR TITLE
fix: resolve CodeQL false positives in retrieval changes

### DIFF
--- a/apps/api/alembic/versions/4a5b6c7d8e9f_add_retrieval_serving_generations.py
+++ b/apps/api/alembic/versions/4a5b6c7d8e9f_add_retrieval_serving_generations.py
@@ -13,6 +13,15 @@ down_revision: str | None = "3f4a5b6c7d8e"
 branch_labels: Sequence[str] | None = None
 depends_on: Sequence[str] | None = None
 
+__all__: list[str] = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+    "upgrade",
+    "downgrade",
+]
+
 
 def upgrade() -> None:
     if not sa.inspect(op.get_bind()).has_table("retrieval_namespace_generations"):

--- a/apps/api/alembic/versions/5b6c7d8e9f0a_add_term_trigram_indexes.py
+++ b/apps/api/alembic/versions/5b6c7d8e9f0a_add_term_trigram_indexes.py
@@ -12,6 +12,15 @@ down_revision: str | None = "4a5b6c7d8e9f"
 branch_labels: Sequence[str] | None = None
 depends_on: Sequence[str] | None = None
 
+__all__: list[str] = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+    "upgrade",
+    "downgrade",
+]
+
 _MAP_UNIT_INDEX = "idx_document_map_units_term_trgm"
 _CHUNK_INDEX = "idx_document_chunks_term_trgm"
 

--- a/apps/api/alembic/versions/6c7d8e9f0a1b_add_retrieval_namespace_map_snapshots.py
+++ b/apps/api/alembic/versions/6c7d8e9f0a1b_add_retrieval_namespace_map_snapshots.py
@@ -13,6 +13,15 @@ down_revision: str | None = "5b6c7d8e9f0a"
 branch_labels: Sequence[str] | None = None
 depends_on: Sequence[str] | None = None
 
+__all__: list[str] = [
+    "revision",
+    "down_revision",
+    "branch_labels",
+    "depends_on",
+    "upgrade",
+    "downgrade",
+]
+
 
 def upgrade() -> None:
     if not sa.inspect(op.get_bind()).has_table("retrieval_namespace_map_snapshots"):

--- a/apps/api/tests/contract/test_retrieval_snapshot_large_corpus_contract.py
+++ b/apps/api/tests/contract/test_retrieval_snapshot_large_corpus_contract.py
@@ -16,7 +16,7 @@ from shared.services.retrieval.nav_snapshot import (
     _REVISION_GROUP_SIZE,
     load_nav_snapshot,
 )
-import shared.services.retrieval.nav_snapshot as nav_snapshot_module
+from shared.services.retrieval import nav_snapshot as nav_snapshot_module
 from sqlalchemy import Executable, Result, select
 from sqlalchemy.engine import Row
 from sqlalchemy.sql.selectable import Select
@@ -63,6 +63,9 @@ class _CountingSession:
             self.chunk_query_count += 1
         result = await self._session.execute(statement)
         return cast(Result[tuple[object, ...]], result)
+
+    async def rollback(self) -> None:
+        await self._session.rollback()
 
 
 async def _seed_large_retrieval_corpus(namespace: str) -> None:

--- a/packages/shared-python/shared/services/retrieval/execution/routes.py
+++ b/packages/shared-python/shared/services/retrieval/execution/routes.py
@@ -56,7 +56,6 @@ async def run_retrieval_route(
 async def _try_run_small_corpus_route(
     context: RetrievalRouteContext,
 ) -> RetrievalRouteOutcome | None:
-    total_chunk_count: int | None = None
     total_chunk_count = await count_scoped_chunks(
         context.db,
         user_id=context.user_id,

--- a/packages/shared-python/shared/services/retrieval/nav_snapshot.py
+++ b/packages/shared-python/shared/services/retrieval/nav_snapshot.py
@@ -26,6 +26,7 @@ from sqlalchemy import (
     tuple_,
 )
 from sqlalchemy.engine import Result
+from sqlalchemy.exc import SQLAlchemyError
 
 from shared.models.database.document import (
     Document,
@@ -393,8 +394,14 @@ async def _resolve_namespace_snapshot_entries(
     )
     try:
         row = (await db.execute(statement)).first()
-    except Exception:
+    except SQLAlchemyError as exc:
         await db.rollback()
+        _logger.warning(
+            "retrieval snapshot namespace lookup failed user_id=%s namespace=%s error=%s",
+            user_id,
+            namespace,
+            exc,
+        )
         return None
     if row is None:
         return None
@@ -470,8 +477,13 @@ async def _resolve_manifest_entries(
         )
         try:
             rows = (await db.execute(statement)).all()
-        except Exception:
+        except SQLAlchemyError as exc:
             await db.rollback()
+            _logger.warning(
+                "retrieval manifest lookup failed revisions=%s error=%s",
+                revision_group,
+                exc,
+            )
             return None
         if len(rows) != len(revision_group):
             return None


### PR DESCRIPTION
## Summary

- Mark Alembic migration metadata as explicit module exports so CodeQL does not report required `revision`, `down_revision`, `branch_labels`, and `depends_on` globals as unused.
- Replace the mixed module import in the large-snapshot contract test.
- Remove redundant route-local initialization.
- Narrow namespace/manifest snapshot lookup fallback handling to `SQLAlchemyError` and log the fallback context.
- Add the missing `rollback()` implementation to the counting session test double.

## Why

Alembic consumes migration metadata by convention, so deleting those globals would break migration discovery. Exporting them via `__all__` is a narrow, repository-local way to communicate that contract to CodeQL while preserving the check elsewhere.

## Verification

- `uv run ruff check ...`
- `uv run pyright ...`
- `pytest apps/api/tests/contract/test_retrieval_serving_manifest_contract.py apps/api/tests/contract/test_retrieval_manifest_cache_contract.py`
- Python compilation and `git diff --check`

The separate classic-route scoring and serving-index projection findings require behavior-level design/contract changes and are intentionally not mixed into this tooling/fallback cleanup PR.
