### PR TITLE
fix: suppress Alembic CodeQL false positives

### DIFF
--- a/apps/api/alembic/versions/4a5b6c7d8e9f_add_retrieval_serving_generations.py
+++ b/apps/api/alembic/versions/4a5b6c7d8e9f_add_retrieval_serving_generations.py
@@ -13,7 +13,7 @@ down_revision: str | None = "3f4a5b6c7d8e"
 branch_labels: Sequence[str] | None = None
 depends_on: Sequence[str] | None = None
 
-__all__: list[str] = [
+__all__ = [
     "revision",
     "down_revision",
     "branch_labels",

--- a/apps/api/alembic/versions/5b6c7d8e9f0a_add_term_trigram_indexes.py
+++ b/apps/api/alembic/versions/5b6c7d8e9f0a_add_term_trigram_indexes.py
@@ -12,7 +12,7 @@ down_revision: str | None = "4a5b6c7d8e9f"
 branch_labels: Sequence[str] | None = None
 depends_on: Sequence[str] | None = None
 
-__all__: list[str] = [
+__all__ = [
     "revision",
     "down_revision",
     "branch_labels",

--- a/apps/api/alembic/versions/6c7d8e9f0a1b_add_retrieval_namespace_map_snapshots.py
+++ b/apps/api/alembic/versions/6c7d8e9f0a1b_add_retrieval_namespace_map_snapshots.py
@@ -13,7 +13,7 @@ down_revision: str | None = "5b6c7d8e9f0a"
 branch_labels: Sequence[str] | None = None
 depends_on: Sequence[str] | None = None
 
-__all__: list[str] = [
+__all__ = [
     "revision",
     "down_revision",
     "branch_labels",


### PR DESCRIPTION
## Summary

- Change the three migration `__all__` declarations from annotated assignments to plain list assignments.
- Preserve Alembic's required `revision`, `down_revision`, `branch_labels`, and `depends_on` metadata.

## Why

The CodeQL `py/unused-global-variable` query recognizes names exported through a simple `__all__` assignment, but not the annotated `__all__: list[str] = ...` form. This keeps the quality check enabled elsewhere without adding per-line suppressions or removing required migration metadata.

## Verification

- `uv run ruff check` on all three migrations
- `uv run pyright` on all three migrations
- `git diff --check`
