### PR TITLE
fix: ignore bare markdown hash lines as headings

### DIFF
--- a/apps/worker/app/services/document_parser/structure/heading_candidates.py
+++ b/apps/worker/app/services/document_parser/structure/heading_candidates.py
@@ -303,6 +303,10 @@ def _estimate_markdown_heading_level(line: str, meta_ctx: Any | None):
     if hash_level <= 0:
         return code_level, code_reason, line_clean
 
+    # "#" / "##" with no title text must not become headings via hash_level alone.
+    if not stripped_line.strip():
+        return -1, f"{hash_level}# AND empty-title {code_reason}", line_clean
+
     if isinstance(code_level, int):
         est_level = max(hash_level, code_level)
     else:


### PR DESCRIPTION
## Summary
- After stripping markdown `#` markers, lines with no title text are no longer treated as headings.
- Titled hash lines still use the existing `max(hash_level, code_level)` path.
- Prevents empty section paths like `file.pdf/` that collapse into Root with a second text chunk.

## Test plan
- [x] `make check` (lint + typecheck)
- [x] Local repro: bare `#` / `##` → level -1; `# Title` keeps positive level and max path
- [x] Local e2e: bare `#` no longer flushes a trailing-slash empty section under Root

Made with [Cursor](https://cursor.com)