### PR TITLE
perf: avoid repeated section scans in map discovery

### DIFF
--- a/packages/shared-python/shared/services/retrieval/search/map_unit_discovery.py
+++ b/packages/shared-python/shared/services/retrieval/search/map_unit_discovery.py
@@ -75,6 +75,25 @@ WITH scoped_units AS (
 )
 """
 
+_SCOPED_UNIT_IDS_CTE = """
+WITH scoped_units AS (
+    SELECT
+        dmu.id AS map_unit_id,
+        dmu.document_id,
+        dmu.job_result_id
+    FROM document_map_units dmu
+    JOIN documents d
+        ON d.document_id = dmu.document_id
+        {revision_join}
+    WHERE d.user_id = :user_id
+        AND d.namespace = :namespace
+        AND d.status = 'active'
+        {revision_clause}
+        {exclude_clause}
+        {type_clause}
+)
+"""
+
 
 @dataclass
 class DiscoveryResult:
@@ -287,7 +306,16 @@ async def map_unit_discovery(
 
     frequency_result = await db.execute(
         text(
-            cte
+            (
+                cte
+                if signal_paths
+                else _SCOPED_UNIT_IDS_CTE.format(
+                    revision_join=revision_join,
+                    revision_clause=revision_clause,
+                    exclude_clause=exclude_clause,
+                    type_clause=type_clause,
+                )
+            )
             + """
                 SELECT tokens.map_unit_id, tokens.channel, tokens.token, tokens.frequency
                 FROM document_map_unit_tokens AS tokens
@@ -310,7 +338,16 @@ async def map_unit_discovery(
 
     index_result = await db.execute(
         text(
-            cte
+            (
+                cte
+                if signal_paths
+                else _SCOPED_UNIT_IDS_CTE.format(
+                    revision_join=revision_join,
+                    revision_clause=revision_clause,
+                    exclude_clause=exclude_clause,
+                    type_clause=type_clause,
+                )
+            )
             + """
                 SELECT indexes.average_idf_path, indexes.average_idf_content,
                        indexes.unit_count


### PR DESCRIPTION
## Summary

Fixes the production statement timeout in map-unit discovery for large namespaces.

The frequency and index-stat queries previously reused the full `scoped_units` CTE, including a `document_sections` join and all section paths. For a 644-document namespace this repeated scan over 42,794 map units and caused `asyncpg.exceptions.QueryCanceledError` under the 30-second statement timeout.

This change adds a lightweight map-unit-ID CTE for frequency and index-stat lookups. The full section join remains only where section-path filtering is required.

## Production evidence

Against the repaired read-only production namespace:

- 644 active documents
- 42,794 indexed map units
- 644 matching manifests and indexes
- The full scoped query took about 12.4 seconds; the repeated frequency query was the statement canceled in production.

## Validation

- Map-unit and classic retrieval contract tests: 6 passed.
- Ruff: passed.

No production writes were performed.
