### PR TITLE
fix(retrieval): enable production node filter

### DIFF
--- a/packages/shared-python/shared/services/retrieval/nav_config.py
+++ b/packages/shared-python/shared/services/retrieval/nav_config.py
@@ -61,7 +61,7 @@ _PRODUCTION_NAV_DICT: dict[str, Any] = {
     "max_waves": 0,
     "max_harvest_depth": 3,
     "plan_control_digest_chars": 600,
-    "enable_node_filter": False,
+    "enable_node_filter": True,
     "filter_max_rounds": 3,
     "filter_min_hits": 1,
     "filter_max_hits": 40,

--- a/packages/shared-python/shared/tests/test_nav_bridge_config.py
+++ b/packages/shared-python/shared/tests/test_nav_bridge_config.py
@@ -41,6 +41,7 @@ def test_build_nav_config_is_checklist_map_trim_stack() -> None:
     assert cfg.planner_thinking == "enabled"
     assert cfg.planner_think_max_tokens == 16_384
     assert cfg.token_limit == 100_000
+    assert cfg.enable_node_filter is True
     assert not hasattr(cfg, "llm_model_env")
 
 


### PR DESCRIPTION
## Summary
- enable the production map-nav node filter
- add a config contract assertion so the production default remains enabled

## Verification
- `uv run pytest packages/shared-python/shared/tests/test_nav_bridge_config.py` (3 passed)

Base branch: `fix/wangbinqi/persist-prod-api-memory`