### PR TITLE
fix: make statistics backfill runnable in API image

### DIFF
--- a/apps/api/scripts/backfill_map_unit_statistics.py
+++ b/apps/api/scripts/backfill_map_unit_statistics.py
@@ -17,17 +17,23 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
+def _resolve_shared_root(api_root: Path) -> Path:
+    """Resolve shared-python in source checkouts and runtime images."""
+    runtime_shared_root = api_root / "packages" / "shared-python"
+    if runtime_shared_root.is_dir():
+        return runtime_shared_root
+
+    repository_root = api_root.parent.parent
+    repository_shared_root = repository_root / "packages" / "shared-python"
+    if repository_shared_root.is_dir():
+        return repository_shared_root
+
+    raise RuntimeError(f"Could not locate shared-python package from {api_root}")
+
+
 def _bootstrap_python_path() -> None:
     api_root = Path(__file__).resolve().parents[1]
-    candidate_roots = (
-        api_root / "packages" / "shared-python",
-        api_root.parents[1] / "packages" / "shared-python",
-    )
-    shared_root = next(
-        (path for path in candidate_roots if path.is_dir()), None
-    )
-    if shared_root is None:
-        raise RuntimeError("Could not locate shared-python package")
+    shared_root = _resolve_shared_root(api_root)
     for path in (api_root, shared_root):
         value = os.fspath(path)
         if value not in sys.path:

--- a/apps/api/tests/contract/test_backfill_map_unit_indexes_contract.py
+++ b/apps/api/tests/contract/test_backfill_map_unit_indexes_contract.py
@@ -32,6 +32,31 @@ def test_backfill_script_resolves_shared_package_from_source_checkout_layout(
     assert _resolve_shared_root(api_root) == shared_root
 
 
+def test_statistics_backfill_resolves_shared_package_from_runtime_image_layout(
+    tmp_path: Path,
+) -> None:
+    from scripts.backfill_map_unit_statistics import _resolve_shared_root
+
+    api_root = tmp_path / "app"
+    shared_root = api_root / "packages" / "shared-python"
+    shared_root.mkdir(parents=True)
+
+    assert _resolve_shared_root(api_root) == shared_root
+
+
+def test_statistics_backfill_resolves_shared_package_from_source_checkout_layout(
+    tmp_path: Path,
+) -> None:
+    from scripts.backfill_map_unit_statistics import _resolve_shared_root
+
+    repository_root = tmp_path / "repository"
+    api_root = repository_root / "apps" / "api"
+    shared_root = repository_root / "packages" / "shared-python"
+    shared_root.mkdir(parents=True)
+
+    assert _resolve_shared_root(api_root) == shared_root
+
+
 def test_statistics_backfill_aggregates_positive_lengths_per_channel() -> None:
     from scripts.backfill_map_unit_statistics import (
         RevisionStatistics,


### PR DESCRIPTION
## Summary

- Fix runtime path resolution for `/app/scripts/backfill_map_unit_statistics.py`.
- Avoid indexing beyond the root path when the API image does not contain a repository checkout.
- Keep source-checkout and runtime-image layouts supported.
- Add contract coverage for both layouts.

## Validation

- `uv run pytest -q apps/api/tests/contract/test_backfill_map_unit_indexes_contract.py`
- `uv run ruff check apps/api/scripts/backfill_map_unit_statistics.py apps/api/tests/contract/test_backfill_map_unit_indexes_contract.py`

Related to #382: the original serving-index rollout PR is already merged; this follow-up unblocks the statistics backfill task.