### PR TITLE
perf(retrieval): cherry-pick content trigram index to main

### DIFF
--- a/apps/api/alembic/versions/0a1b2c3d4e5f_add_content_trigram_index.py
+++ b/apps/api/alembic/versions/0a1b2c3d4e5f_add_content_trigram_index.py
@@ -1,0 +1,46 @@
+"""Add trigram acceleration for regex searches over published chunk content."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+
+
+revision: str = "0a1b2c3d4e5f"
+down_revision: str | None = "9f0a1b2c3d4e"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+_INDEX_NAME = "idx_document_chunks_content_trgm"
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    external_transaction = bool(
+        op.get_context().opts.get("knowhere_external_transaction", False)
+    )
+    if external_transaction:
+        op.execute(
+            f"CREATE INDEX IF NOT EXISTS {_INDEX_NAME} "
+            "ON document_chunks USING gin (content gin_trgm_ops) "
+            "WHERE content IS NOT NULL"
+        )
+        return
+    with op.get_context().autocommit_block():
+        op.execute(
+            f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {_INDEX_NAME} "
+            "ON document_chunks USING gin (content gin_trgm_ops) "
+            "WHERE content IS NOT NULL"
+        )
+
+
+def downgrade() -> None:
+    external_transaction = bool(
+        op.get_context().opts.get("knowhere_external_transaction", False)
+    )
+    if external_transaction:
+        op.execute(f"DROP INDEX IF EXISTS {_INDEX_NAME}")
+        return
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}")

--- a/apps/api/tests/migrations/test_schema_contract.py
+++ b/apps/api/tests/migrations/test_schema_contract.py
@@ -413,6 +413,26 @@ def test_should_add_per_channel_map_unit_bm25_statistics(
         "content_document_count": "YES",
         "content_total_length": "YES",
     }
+def test_should_create_content_trigram_index_for_regex_search(
+    migrated_head_engine: Engine,
+) -> None:
+    with migrated_head_engine.begin() as connection:
+        index_definition = connection.execute(
+            text(
+                """
+                SELECT pg_get_indexdef(indexes.indexrelid)
+                FROM pg_index AS indexes
+                JOIN pg_class AS classes ON classes.oid = indexes.indexrelid
+                JOIN pg_namespace AS namespaces ON namespaces.oid = classes.relnamespace
+                WHERE namespaces.nspname = current_schema()
+                  AND classes.relname = 'idx_document_chunks_content_trgm'
+                """
+            )
+        ).scalar_one()
+
+    definition = str(index_definition)
+    assert "USING gin (content gin_trgm_ops)" in definition
+    assert "WHERE (content IS NOT NULL)" in definition
 
 
 def test_should_upgrade_with_a_caller_owned_connection(


### PR DESCRIPTION
## Summary
- cherry-pick the content trigram migration from staging into main
- preserve main branch migration contract tests while adding the content index contract

## Source
- Staging PR: https://github.com/Ontos-AI/knowhere/pull/384
- Source commit: cc4690c2

## Verification
- `uv run pytest apps/api/tests/migrations/test_schema_contract.py -q` (16 passed)
- `uv run ruff check` (passed)
- `git diff --check` (passed)

This PR is intentionally based on `main` for the authorized cherry-pick delivery.