### PR TITLE
fix: clear CodeQL alerts on agent_tools tool registration

### DIFF
--- a/apps/api/app/mcp/dynamic_tools.py
+++ b/apps/api/app/mcp/dynamic_tools.py
@@ -24,7 +24,6 @@ from pydantic import create_model
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from shared.services.retrieval.agent_tools import REGISTRY, ToolContext, ToolSpec
-from shared.services.retrieval.agent_tools import tools as _agent_tools_registered  # noqa: F401
 
 DbFactory = Callable[[], AsyncContextManager[AsyncSession]]
 

--- a/packages/shared-python/shared/services/retrieval/agent_explore/harness/base.py
+++ b/packages/shared-python/shared/services/retrieval/agent_explore/harness/base.py
@@ -39,4 +39,4 @@ class Harness(Protocol):
         so concurrent tool calls (a real Cursor SDK behavior, not just a
         theoretical one — see ``harness/cursor_harness.py``) are always safe.
         """
-        ...
+        raise NotImplementedError

--- a/packages/shared-python/shared/services/retrieval/agent_explore/harness/cursor_harness.py
+++ b/packages/shared-python/shared/services/retrieval/agent_explore/harness/cursor_harness.py
@@ -93,7 +93,6 @@ from shared.services.retrieval.agent_tools import (
     ToolResult,
     load_corpus_schema_text,
 )
-from shared.services.retrieval.agent_tools import tools as _agent_tools_registered  # noqa: F401
 
 # Grace period for the underlying agent run to actually stop, after a
 # best-effort run.cancel() following a wall_clock timeout, before this

--- a/packages/shared-python/shared/services/retrieval/agent_explore/harness/openai_harness.py
+++ b/packages/shared-python/shared/services/retrieval/agent_explore/harness/openai_harness.py
@@ -77,7 +77,6 @@ from shared.services.retrieval.agent_explore.shared import (
 )
 from shared.services.retrieval.agent_explore.types import AgentStep, EpisodeResult
 from shared.services.retrieval.agent_tools import REGISTRY, ToolBudget, load_corpus_schema_text
-from shared.services.retrieval.agent_tools import tools as _agent_tools_registered  # noqa: F401
 
 # A tool-role message is kept in full for the turn it was produced plus this
 # many additional turns, then collapsed to a placeholder — see module

--- a/packages/shared-python/shared/services/retrieval/agent_tools/__init__.py
+++ b/packages/shared-python/shared/services/retrieval/agent_tools/__init__.py
@@ -9,7 +9,9 @@ parse artifacts.
 The same ``REGISTRY`` is meant to be consumed by two harnesses (Phase 3):
 the API ``/mcp`` server (Cursor/Codex/Claude) and the in-process
 ``agent_explore`` tool-loop. Importing ``agent_tools.tools`` registers every
-tool as a side effect.
+tool as a side effect; this package performs that import itself (below), so
+any consumer importing a name here (e.g. ``REGISTRY``) is guaranteed a fully
+populated registry.
 """
 
 from __future__ import annotations
@@ -26,7 +28,17 @@ from shared.services.retrieval.agent_tools.registry import (
 )
 from shared.services.retrieval.agent_tools.schema_doc import load_corpus_schema_text
 
+# Register every ``corpus.*`` tool into ``REGISTRY`` as an import side effect:
+# each module under ``tools/`` calls ``@register_tool`` at import time. Kept
+# here — not in ``registry.py``, which the tool modules import and would
+# therefore create a cycle — so consumers importing any name from this package
+# no longer need their own side-effect import of ``tools``. ``_tools`` is
+# intentionally never referenced (listed in ``__all__`` as a deliberate
+# re-export so tooling does not flag it as unused).
+from shared.services.retrieval.agent_tools import tools as _tools
+
 __all__ = [
+    "_tools",
     "REGISTRY",
     "ToolBudget",
     "ToolContext",


### PR DESCRIPTION
Closes the remaining CodeQL findings that were auto-posted as comments on the main→staging PR #396. Three of the seven alerts (417–419: redundant `stop_reason` assignment, 2× implicit string concatenation) were already fixed on `main` by the Copilot-Autofix commits `b6a95a8f`/`7a0a51b8` — no further work needed there.

## Changes

1. **`harness/base.py`** — CodeQL *statement has no effect* (alert 420): the `...` placeholder inside the `Harness` Protocol method is dead code. Replaced with `raise NotImplementedError`, matching the convention used by other Protocols in this repo.

2. **`agent_tools/__init__.py`** — the tool-registration side-effect import (each module under `tools/` calls `@register_tool` at import time) is now performed by the package itself, so any consumer importing a name from this package (e.g. `REGISTRY`) is guaranteed a fully populated registry. `_tools` is listed in `__all__` as a deliberate re-export (ruff already ignores F401 in `__init__.py`).

3. **Dropped the 3 redundant `import tools as _agent_tools_registered  # noqa: F401` lines** in `dynamic_tools.py`, `cursor_harness.py`, `openai_harness.py` — CodeQL *unused import* alerts 421/422/423. These were false positives in the sense that the imports are load-bearing (deleting them outright would leave `REGISTRY.all()` empty at runtime), but after change 2 they are genuinely redundant.

## Verification

- `ruff check` clean on all affected files and packages.
- `pyright` clean on changed files (only pre-existing optional `cursor-sdk` missing-import note).
- Import smoke tests: plain `import agent_tools` now registers all 8 `corpus.*` tools; `openai_harness`, `cursor_harness`, `dynamic_tools`, and `retrieval_server` all import cleanly with a populated registry (no import-cycle introduced).