### PR TITLE
fix(tests): remove duplicate migration contract

### DIFF
--- a/apps/api/tests/migrations/test_schema_contract.py
+++ b/apps/api/tests/migrations/test_schema_contract.py
@@ -435,26 +435,6 @@ def test_should_add_per_channel_map_unit_bm25_statistics(
         "content_document_count": "YES",
         "content_total_length": "YES",
     }
-def test_should_create_content_trigram_index_for_regex_search(
-    migrated_head_engine: Engine,
-) -> None:
-    with migrated_head_engine.begin() as connection:
-        index_definition = connection.execute(
-            text(
-                """
-                SELECT pg_get_indexdef(indexes.indexrelid)
-                FROM pg_index AS indexes
-                JOIN pg_class AS classes ON classes.oid = indexes.indexrelid
-                JOIN pg_namespace AS namespaces ON namespaces.oid = classes.relnamespace
-                WHERE namespaces.nspname = current_schema()
-                  AND classes.relname = 'idx_document_chunks_content_trgm'
-                """
-            )
-        ).scalar_one()
-
-    definition = str(index_definition)
-    assert "USING gin (content gin_trgm_ops)" in definition
-    assert "WHERE (content IS NOT NULL)" in definition
 
 
 def test_should_upgrade_with_a_caller_owned_connection(


### PR DESCRIPTION
## Summary
- remove the duplicate `test_should_create_content_trigram_index_for_regex_search` definition
- keep the migration contract covered once

## Verification
- `make lint`
- `uv run --all-packages pytest apps/api/tests/migrations/test_schema_contract.py -k content_trigram --collect-only -q`

This fixes the `Lint` failure from run [34327278503](https://github.com/Ontos-AI/knowhere/actions/runs/34327278503/job/102387331886), where Ruff reported `F811`.